### PR TITLE
Support MSE/PE encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ v0.5.0 (in development)
 - Fix "Saving torrent to file" message when torrent is actually being written
   to stdout
 - Added support for configuration files
+- Added support for MSE/PE-encrypted peer connections
 
 v0.4.0 (2025-05-17)
 -------------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "patharg",
  "pin-project-lite",
  "rand",
+ "rand_chacha",
  "rc4",
  "reqwest",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,10 +342,14 @@ dependencies = [
  "dirs",
  "fern",
  "futures-util",
+ "generic-array",
  "log",
+ "num-bigint",
+ "num_enum",
  "patharg",
  "pin-project-lite",
  "rand",
+ "rc4",
  "reqwest",
  "rstest",
  "serde",
@@ -723,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -814,9 +828,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -830,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -880,6 +894,15 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1000,12 +1023,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1166,6 +1229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1343,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rc4"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1256e23efe6097f27aa82d6ca6889361c001586ae0f6917cbad072f05eb275"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -2190,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,14 @@ data-encoding = "2.6.0"
 dirs = "6.0.0"
 fern = "0.7.0"
 futures-util = { version = "0.3.30", default-features = false, features = ["sink"] }
+generic-array = "0.14.7"
 log = "0.4.21"
+num-bigint = "0.4.6"
+num_enum = "0.7.3"
 patharg = { version = "0.4.0", features = ["tokio"] }
 pin-project-lite = "0.2.14"
 rand = "0.9.0"
+rc4 = "0.1.0"
 reqwest = { version = "0.12.4", default-features = false, features = ["http2"] }
 serde = { version = "1.0.219", features = ["derive"] }
 sha1 = "0.10.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ thiserror = "2.0.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.14"
+rand_chacha = "0.9.0"
 rstest = { version = "0.25.0", default-features = false }
 tempfile = "3.10.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["/.*"]
 anstream = "0.6.14"
 anstyle = "1.0.7"
 bendy = "0.3.3"
-bytes = "1.6.0"
+bytes = "1.7.0"
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std"] }
 clap = { version = "4.5.4", default-features = false, features = ["derive", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
 data-encoding = "2.6.0"

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ protocol.  The following notable features are supported:
 - Fast extension ([BEP 6](https://www.bittorrent.org/beps/bep_0006.html))
 - UDP tracker protocol extensions ([BEP
   41](https://www.bittorrent.org/beps/bep_0041.html))
+- MSE/PE Encryption
 
 The following features are not currently supported but are planned, in no
 particular order:
 
-- Encryption
 - Distributed hash tables
 - BitTorrent protocol v2
 - `x.pe` parameters in magnet links
@@ -163,6 +163,15 @@ in the form "IP:PORT".
 
 - `-J`, `--json` — Print out the peers as JSON objects, one per line
 
+- `--no-crypto` — Do not tell the tracker anything about our encryption
+  support.  Overrides the `peers.encryption-preference` configuration setting.
+
+- `--require-crypto` — Tell the tracker that we require peers with encryption
+  support.  Overrides the `peers.encryption-preference` configuration setting.
+
+- `--support-crypto` — Tell the tracker that we support the encrypted peer
+  protocol.  Overrides the `peers.encryption-preference` configuration setting.
+
 
 `demagnetize query-peer`
 ------------------------
@@ -182,12 +191,22 @@ information.
 
 ### Options
 
+- `--encrypt` — Create an encrypted connection to the peer.  Overrides the
+  `peers.encryption-preference` configuration setting.
+
+- `--no-encrypt` — Create an unencrypted connection to the peer.  Overrides the
+  `peers.encryption-preference` configuration setting.
+
 - `-o PATH`, `--outfile PATH` — Save the `.torrent` file to the given path.
   The path may contain a `{name}` placeholder, which will be replaced by the
   (sanitized) name of the torrent, and/or a `{hash}` placeholder, which will be
   replaced by the torrent's info hash in hexadecimal.  Specifying `-` will
   cause the torrent to be written to standard output.  [default:
   `{name}.torrent`]
+
+- `--try-encrypt` — Attempt to create an encrypted connection to the peer; if
+  that fails, try again without encryption.  Overrides the
+  `peers.encryption-preference` configuration setting.
 
 
 Configuration
@@ -211,6 +230,24 @@ This file may contain the following tables & keys, all of which are optional:
       the handshake for an encrypted peer connection, wait this many seconds
       for the remote peer to send its portion of the Diffie-Hellman key
       exchange.
+    - `encryption-preference` — Configures when to use MSE/PE encryption when
+      connecting to peers.  The possible options are:
+        - `"always"` – Always use encryption.  Also causes announcements to
+          HTTP trackers to include a `requirecrypto=1` parameter.
+        - `"fallback"` — Try creating an encrypted connection first; if the
+          encryption handshake fails, and the peer does not require encryption,
+          try again with an unencrypted connection.  Also causes announcements
+          to HTTP trackers to include a `supportcrypto=1` parameter.
+            - This is the default.
+            - Note that falling back to an unencrypted connection resets the
+              peer handshake timeout (see `handshake-timeout` below).
+        - `"if-required"` — Only use encryption if the returning tracker
+          indicated that the peer requires encryption.  Also causes
+          announcements to HTTP trackers to include a `supportcrypto=1`
+          parameter.
+        - `"never"` — Do not use encryption; do not attempt to connect to peers
+          that require encryption.  Also causes announcements to HTTP trackers
+          to not include a crypto parameter.
     - `handshake-timeout` (nonnegative integer; default 60) — When connecting
       to a peer, if the TCP connection, encryption handshake, and BitTorrent
       handshake are not all completed within this many seconds, the peer is

--- a/README.md
+++ b/README.md
@@ -207,9 +207,14 @@ This file may contain the following tables & keys, all of which are optional:
       magnet links that the `batch` command will operate on at once
 
 - `[peers]` — settings for interacting with peers
+    - `dh-exchange-timeout` (nonnegative integer; default 30) — When performing
+      the handshake for an encrypted peer connection, wait this many seconds
+      for the remote peer to send its portion of the Diffie-Hellman key
+      exchange.
     - `handshake-timeout` (nonnegative integer; default 60) — When connecting
-      to a peer, if the TCP connection and BitTorrent handshake are not both
-      completed within this many seconds, the peer is abandoned.
+      to a peer, if the TCP connection, encryption handshake, and BitTorrent
+      handshake are not all completed within this many seconds, the peer is
+      abandoned.
     - `jobs-per-magnet` (positive integer; default 30) — the maximum number of
       peers per magnet link that `demagnetize` will communicate with at once
 

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ information.
   cause the torrent to be written to standard output.  [default:
   `{name}.torrent`]
 
-- `--try-encrypt` — Attempt to create an encrypted connection to the peer; if
-  that fails, try again without encryption.  Overrides the
+- `--prefer-encrypt` — Attempt to create an encrypted connection to the peer;
+  if that fails, try again without encryption.  Overrides the
   `peers.encryption-preference` configuration setting.
 
 
@@ -234,7 +234,7 @@ This file may contain the following tables & keys, all of which are optional:
       connecting to peers.  The possible options are:
         - `"always"` – Always use encryption.  Also causes announcements to
           HTTP trackers to include a `requirecrypto=1` parameter.
-        - `"fallback"` — Try creating an encrypted connection first; if the
+        - `"prefer"` — Try creating an encrypted connection first; if the
           encryption handshake fails, and the peer does not require encryption,
           try again with an unencrypted connection.  Also causes announcements
           to HTTP trackers to include a `supportcrypto=1` parameter.

--- a/README.md
+++ b/README.md
@@ -164,13 +164,13 @@ in the form "IP:PORT".
 - `-J`, `--json` — Print out the peers as JSON objects, one per line
 
 - `--no-crypto` — Do not tell the tracker anything about our encryption
-  support.  Overrides the `peers.encryption-preference` configuration setting.
+  support.  Overrides the `general.encrypt` configuration setting.
 
 - `--require-crypto` — Tell the tracker that we require peers with encryption
-  support.  Overrides the `peers.encryption-preference` configuration setting.
+  support.  Overrides the `general.encrypt` configuration setting.
 
 - `--support-crypto` — Tell the tracker that we support the encrypted peer
-  protocol.  Overrides the `peers.encryption-preference` configuration setting.
+  protocol.  Overrides the `general.encrypt` configuration setting.
 
 
 `demagnetize query-peer`
@@ -192,10 +192,10 @@ information.
 ### Options
 
 - `--encrypt` — Create an encrypted connection to the peer.  Overrides the
-  `peers.encryption-preference` configuration setting.
+  `general.encrypt` configuration setting.
 
 - `--no-encrypt` — Create an unencrypted connection to the peer.  Overrides the
-  `peers.encryption-preference` configuration setting.
+  `general.encrypt` configuration setting.
 
 - `-o PATH`, `--outfile PATH` — Save the `.torrent` file to the given path.
   The path may contain a `{name}` placeholder, which will be replaced by the
@@ -205,8 +205,8 @@ information.
   `{name}.torrent`]
 
 - `--prefer-encrypt` — Attempt to create an encrypted connection to the peer;
-  if that fails, try again without encryption.  Overrides the
-  `peers.encryption-preference` configuration setting.
+  if that fails, try again without encryption.  Overrides the `general.encrypt`
+  configuration setting.
 
 
 Configuration
@@ -224,30 +224,30 @@ This file may contain the following tables & keys, all of which are optional:
 - `[general]` — settings that don't fit anywhere more specific
     - `batch-jobs` (positive integer; default 50) — the maximum number of
       magnet links that the `batch` command will operate on at once
+    - `encrypt` — Configures when to use MSE/PE encryption when connecting to
+      peers and what to tell HTTP trackers about encryption support.  The
+      possible options are:
+        - `"always"` – Always use encryption with peers, and include a
+          `requirecrypto=1` parameter in announcements to HTTP trackers
+        - `"prefer"` — Try creating an encrypted connection to a peer first; if
+          the encryption handshake fails, and the peer does not require
+          encryption, try again without encryption.  Also include a
+          `supportcrypto=1` parameter in announcements to HTTP trackers.
+            - This is the default.
+            - Note that falling back to an unencrypted connection resets the
+              peer handshake timeout (See `peers.handshake-timeout` below).
+        - `"if-required"` — Only use encryption if the returning tracker
+          indicated that the peer requires encryption, and include a
+          `supportcrypto=1` parameter in announcements to HTTP trackers.
+        - `"never"` — Do not use encryption; do not attempt to connect to peers
+          that require encryption; do not include any crypto parameters in
+          announcements to HTTP trackers
 
 - `[peers]` — settings for interacting with peers
     - `dh-exchange-timeout` (nonnegative integer; default 30) — When performing
       the handshake for an encrypted peer connection, wait this many seconds
       for the remote peer to send its portion of the Diffie-Hellman key
       exchange.
-    - `encryption-preference` — Configures when to use MSE/PE encryption when
-      connecting to peers.  The possible options are:
-        - `"always"` – Always use encryption.  Also causes announcements to
-          HTTP trackers to include a `requirecrypto=1` parameter.
-        - `"prefer"` — Try creating an encrypted connection first; if the
-          encryption handshake fails, and the peer does not require encryption,
-          try again with an unencrypted connection.  Also causes announcements
-          to HTTP trackers to include a `supportcrypto=1` parameter.
-            - This is the default.
-            - Note that falling back to an unencrypted connection resets the
-              peer handshake timeout (see `handshake-timeout` below).
-        - `"if-required"` — Only use encryption if the returning tracker
-          indicated that the peer requires encryption.  Also causes
-          announcements to HTTP trackers to include a `supportcrypto=1`
-          parameter.
-        - `"never"` — Do not use encryption; do not attempt to connect to peers
-          that require encryption.  Also causes announcements to HTTP trackers
-          to not include a crypto parameter.
     - `handshake-timeout` (nonnegative integer; default 60) — When connecting
       to a peer, if the TCP connection, encryption handshake, and BitTorrent
       handshake are not all completed within this many seconds, the peer is

--- a/THIRDPARTY.toml
+++ b/THIRDPARTY.toml
@@ -4236,6 +4236,248 @@ limitations under the License.
 """
 
 [[third_party_libraries]]
+package_name = "cipher"
+package_version = "0.4.4"
+repository = "https://github.com/RustCrypto/traits"
+license = "MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Copyright (c) 2016-2020 RustCrypto Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the \"Software\"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   \"License\" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   \"Licensor\" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   \"Legal Entity\" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   \"control\" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   \"You\" (or \"Your\") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   \"Source\" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   \"Object\" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   \"Work\" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   \"Derivative Works\" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   \"Contribution\" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, \"submitted\"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as \"Not a Contribution.\"
+
+   \"Contributor\" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a \"NOTICE\" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets \"[]\"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same \"printed page\" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+[[third_party_libraries]]
 package_name = "clap"
 package_version = "4.5.38"
 repository = "https://github.com/clap-rs/clap"
@@ -13813,7 +14055,7 @@ limitations under the License.
 
 [[third_party_libraries]]
 package_name = "hyper-util"
-package_version = "0.1.11"
+package_version = "0.1.12"
 repository = "https://github.com/hyperium/hyper-util"
 license = "MIT"
 
@@ -14555,7 +14797,7 @@ ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation a
 
 [[third_party_libraries]]
 package_name = "icu_properties"
-package_version = "2.0.0"
+package_version = "2.0.1"
 repository = "https://github.com/unicode-org/icu4x"
 license = "Unicode-3.0"
 
@@ -14612,7 +14854,7 @@ ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation a
 
 [[third_party_libraries]]
 package_name = "icu_properties_data"
-package_version = "2.0.0"
+package_version = "2.0.1"
 repository = "https://github.com/unicode-org/icu4x"
 license = "Unicode-3.0"
 
@@ -15448,6 +15690,249 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+"""
+
+[[third_party_libraries]]
+package_name = "inout"
+package_version = "0.1.4"
+repository = "https://github.com/RustCrypto/utils"
+license = "MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Copyright (c) 2022 The RustCrypto Project Developers
+Copyright (c) 2022 Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the \"Software\"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   \"License\" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   \"Licensor\" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   \"Legal Entity\" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   \"control\" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   \"You\" (or \"Your\") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   \"Source\" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   \"Object\" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   \"Work\" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   \"Derivative Works\" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   \"Contribution\" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, \"submitted\"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as \"Not a Contribution.\"
+
+   \"Contributor\" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a \"NOTICE\" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets \"[]\"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same \"printed page\" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 """
 
 [[third_party_libraries]]
@@ -18432,6 +18917,490 @@ text = """
 """
 
 [[third_party_libraries]]
+package_name = "num-bigint"
+package_version = "0.4.6"
+repository = "https://github.com/rust-num/num-bigint"
+license = "MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the \"Software\"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   \"License\" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   \"Licensor\" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   \"Legal Entity\" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   \"control\" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   \"You\" (or \"Your\") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   \"Source\" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   \"Object\" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   \"Work\" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   \"Derivative Works\" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   \"Contribution\" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, \"submitted\"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as \"Not a Contribution.\"
+
+   \"Contributor\" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a \"NOTICE\" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets \"[]\"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same \"printed page\" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+\thttp://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+[[third_party_libraries]]
+package_name = "num-integer"
+package_version = "0.1.46"
+repository = "https://github.com/rust-num/num-integer"
+license = "MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the \"Software\"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   \"License\" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   \"Licensor\" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   \"Legal Entity\" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   \"control\" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   \"You\" (or \"Your\") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   \"Source\" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   \"Object\" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   \"Work\" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   \"Derivative Works\" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   \"Contribution\" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, \"submitted\"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as \"Not a Contribution.\"
+
+   \"Contributor\" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a \"NOTICE\" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets \"[]\"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same \"printed page\" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+\thttp://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+[[third_party_libraries]]
 package_name = "num-traits"
 package_version = "0.2.19"
 repository = "https://github.com/rust-num/num-traits"
@@ -18671,6 +19640,500 @@ distributed under the License is distributed on an \"AS IS\" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+"""
+
+[[third_party_libraries]]
+package_name = "num_enum"
+package_version = "0.7.3"
+repository = "https://github.com/illicitonion/num_enum"
+license = "BSD-3-Clause OR MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "BSD-3-Clause"
+text = """
+Copyright (c) 2018, Daniel Wagner-Hall
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of num_enum nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the \"Software\"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   \"License\" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   \"Licensor\" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   \"Legal Entity\" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   \"control\" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   \"You\" (or \"Your\") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   \"Source\" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   \"Object\" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   \"Work\" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   \"Derivative Works\" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   \"Contribution\" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, \"submitted\"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as \"Not a Contribution.\"
+
+   \"Contributor\" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a \"NOTICE\" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+"""
+
+[[third_party_libraries]]
+package_name = "num_enum_derive"
+package_version = "0.7.3"
+repository = "https://github.com/illicitonion/num_enum"
+license = "BSD-3-Clause OR MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "BSD-3-Clause"
+text = """
+Copyright (c) 2018, Daniel Wagner-Hall
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of num_enum nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the \"Software\"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   \"License\" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   \"Licensor\" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   \"Legal Entity\" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   \"control\" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   \"You\" (or \"Your\") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   \"Source\" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   \"Object\" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   \"Work\" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   \"Derivative Works\" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   \"Contribution\" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, \"submitted\"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as \"Not a Contribution.\"
+
+   \"Contributor\" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a \"NOTICE\" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
 """
 
 [[third_party_libraries]]
@@ -21299,6 +22762,246 @@ limitations under the License.
 """
 
 [[third_party_libraries]]
+package_name = "proc-macro-crate"
+package_version = "3.3.0"
+repository = "https://github.com/bkchr/proc-macro-crate"
+license = "MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the \"Software\"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                              Apache License
+                        Version 2.0, January 2004
+                     https://www.apache.org/licenses/LICENSE-2.0
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   \"License\" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   \"Licensor\" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   \"Legal Entity\" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   \"control\" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   \"You\" (or \"Your\") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   \"Source\" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   \"Object\" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   \"Work\" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   \"Derivative Works\" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   \"Contribution\" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, \"submitted\"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as \"Not a Contribution.\"
+
+   \"Contributor\" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a \"NOTICE\" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets \"[]\"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same \"printed page\" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+\thttps://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+[[third_party_libraries]]
 package_name = "proc-macro2"
 package_version = "1.0.95"
 repository = "https://github.com/dtolnay/proc-macro2"
@@ -23081,6 +24784,249 @@ APPENDIX: How to apply the Apache License to your work.
    file or class name and description of purpose be included on the
    same \"printed page\" as the copyright notice for easier
    identification within third-party archives.
+"""
+
+[[third_party_libraries]]
+package_name = "rc4"
+package_version = "0.1.0"
+repository = "https://github.com/RustCrypto/stream-ciphers"
+license = "MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Copyright (c) 2006-2009 Graydon Hoare
+Copyright (c) 2009-2013 Mozilla Foundation
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the \"Software\"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   \"License\" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   \"Licensor\" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   \"Legal Entity\" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   \"control\" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   \"You\" (or \"Your\") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   \"Source\" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   \"Object\" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   \"Work\" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   \"Derivative Works\" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   \"Contribution\" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, \"submitted\"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as \"Not a Contribution.\"
+
+   \"Contributor\" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a \"NOTICE\" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets \"[]\"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same \"printed page\" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 """
 
 [[third_party_libraries]]
@@ -36984,7 +38930,7 @@ insights.
 
 [[third_party_libraries]]
 package_name = "windows-core"
-package_version = "0.61.0"
+package_version = "0.61.2"
 repository = "https://github.com/microsoft/windows-rs"
 license = "MIT OR Apache-2.0"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::consts::PEER_ID_PREFIX;
+use crate::tracker::TrackerCrypto;
 use crate::types::{Key, PeerId};
 use rand::Rng;
 use std::fmt;
@@ -8,6 +9,7 @@ use std::fmt;
 pub(crate) struct App {
     pub(crate) cfg: Config,
     pub(crate) local: LocalPeer,
+    pub(crate) tracker_crypto: Option<TrackerCrypto>,
 }
 
 impl App {
@@ -16,7 +18,15 @@ impl App {
         let key = rng.random::<Key>();
         let port = cfg.trackers.local_port.generate(&mut rng);
         let local = LocalPeer { id, key, port };
-        App { cfg, local }
+        App {
+            cfg,
+            local,
+            tracker_crypto: None,
+        }
+    }
+
+    pub(crate) fn get_tracker_crypto(&self) -> TrackerCrypto {
+        self.tracker_crypto.unwrap_or_default()
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,6 @@
 use crate::config::{Config, CryptoPreference};
 use crate::consts::PEER_ID_PREFIX;
 use crate::peer::CryptoMode;
-use crate::tracker::TrackerCrypto;
 use crate::types::{Key, PeerId};
 use rand::Rng;
 use std::fmt;
@@ -10,7 +9,6 @@ use std::fmt;
 pub(crate) struct App {
     pub(crate) cfg: Config,
     pub(crate) local: LocalPeer,
-    pub(crate) tracker_crypto: Option<TrackerCrypto>,
 }
 
 impl App {
@@ -19,20 +17,7 @@ impl App {
         let key = rng.random::<Key>();
         let port = cfg.trackers.local_port.generate(&mut rng);
         let local = LocalPeer { id, key, port };
-        App {
-            cfg,
-            local,
-            tracker_crypto: None,
-        }
-    }
-
-    pub(crate) fn get_tracker_crypto(&self) -> TrackerCrypto {
-        self.tracker_crypto
-            .unwrap_or(match self.cfg.peers.encryption_preference {
-                CryptoPreference::Always => TrackerCrypto::Required,
-                CryptoPreference::Never => TrackerCrypto::Nil,
-                _ => TrackerCrypto::Supported,
-            })
+        App { cfg, local }
     }
 
     pub(crate) fn get_crypto_mode(&self, requires_crypto: bool) -> Option<CryptoMode> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, CryptoPreference};
+use crate::config::Config;
 use crate::consts::PEER_ID_PREFIX;
 use crate::peer::CryptoMode;
 use crate::types::{Key, PeerId};
@@ -21,15 +21,7 @@ impl App {
     }
 
     pub(crate) fn get_crypto_mode(&self, requires_crypto: bool) -> Option<CryptoMode> {
-        match (self.cfg.general.encrypt, requires_crypto) {
-            (CryptoPreference::Always, _) => Some(CryptoMode::Encrypt),
-            (CryptoPreference::Prefer, true) => Some(CryptoMode::Encrypt),
-            (CryptoPreference::Prefer, false) => Some(CryptoMode::Prefer),
-            (CryptoPreference::IfRequired, true) => Some(CryptoMode::Encrypt),
-            (CryptoPreference::IfRequired, false) => Some(CryptoMode::Plain),
-            (CryptoPreference::Never, true) => None,
-            (CryptoPreference::Never, false) => Some(CryptoMode::Plain),
-        }
+        self.cfg.general.encrypt.get_crypto_mode(requires_crypto)
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,8 +23,8 @@ impl App {
     pub(crate) fn get_crypto_mode(&self, requires_crypto: bool) -> Option<CryptoMode> {
         match (self.cfg.peers.encryption_preference, requires_crypto) {
             (CryptoPreference::Always, _) => Some(CryptoMode::Encrypt),
-            (CryptoPreference::Fallback, true) => Some(CryptoMode::Encrypt),
-            (CryptoPreference::Fallback, false) => Some(CryptoMode::Fallback),
+            (CryptoPreference::Prefer, true) => Some(CryptoMode::Encrypt),
+            (CryptoPreference::Prefer, false) => Some(CryptoMode::Prefer),
             (CryptoPreference::IfRequired, true) => Some(CryptoMode::Encrypt),
             (CryptoPreference::IfRequired, false) => Some(CryptoMode::Plain),
             (CryptoPreference::Never, true) => None,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
-use crate::config::Config;
+use crate::config::{Config, CryptoPreference};
 use crate::consts::PEER_ID_PREFIX;
-use crate::peer::CryptoStrategy;
+use crate::peer::CryptoMode;
 use crate::tracker::TrackerCrypto;
 use crate::types::{Key, PeerId};
 use rand::Rng;
@@ -11,7 +11,7 @@ pub(crate) struct App {
     pub(crate) cfg: Config,
     pub(crate) local: LocalPeer,
     pub(crate) tracker_crypto: Option<TrackerCrypto>,
-    pub(crate) crypto_strategy: Option<CryptoStrategy>,
+    pub(crate) crypto_mode: Option<CryptoMode>,
 }
 
 impl App {
@@ -24,21 +24,36 @@ impl App {
             cfg,
             local,
             tracker_crypto: None,
-            crypto_strategy: None,
+            crypto_mode: None,
         }
     }
 
     pub(crate) fn get_tracker_crypto(&self) -> TrackerCrypto {
-        self.tracker_crypto.unwrap_or_default()
+        self.tracker_crypto
+            .unwrap_or(match self.cfg.peers.encryption_preference {
+                CryptoPreference::Always => TrackerCrypto::Required,
+                CryptoPreference::Never => TrackerCrypto::Nil,
+                _ => TrackerCrypto::Supported,
+            })
     }
 
-    pub(crate) fn get_crypto_strategy(&self, requires_crypto: bool) -> Option<CryptoStrategy> {
-        match (self.crypto_strategy, requires_crypto) {
-            (None, true) => Some(CryptoStrategy::Always),
-            (None, false) => Some(CryptoStrategy::Fallback),
-            (Some(CryptoStrategy::Fallback), true) => Some(CryptoStrategy::Always),
-            (Some(CryptoStrategy::Never), true) => None,
-            (Some(cs), _) => Some(cs),
+    pub(crate) fn get_crypto_mode(&self, requires_crypto: bool) -> Option<CryptoMode> {
+        if let Some(cs) = self.crypto_mode {
+            match (cs, requires_crypto) {
+                (CryptoMode::Fallback, true) => Some(CryptoMode::Encrypt),
+                (CryptoMode::Plain, true) => None,
+                (cs, _) => Some(cs),
+            }
+        } else {
+            match (self.cfg.peers.encryption_preference, requires_crypto) {
+                (CryptoPreference::Always, _) => Some(CryptoMode::Encrypt),
+                (CryptoPreference::Fallback, true) => Some(CryptoMode::Encrypt),
+                (CryptoPreference::Fallback, false) => Some(CryptoMode::Fallback),
+                (CryptoPreference::IfRequired, true) => Some(CryptoMode::Encrypt),
+                (CryptoPreference::IfRequired, false) => Some(CryptoMode::Plain),
+                (CryptoPreference::Never, true) => None,
+                (CryptoPreference::Never, false) => Some(CryptoMode::Plain),
+            }
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,6 @@ pub(crate) struct App {
     pub(crate) cfg: Config,
     pub(crate) local: LocalPeer,
     pub(crate) tracker_crypto: Option<TrackerCrypto>,
-    pub(crate) crypto_mode: Option<CryptoMode>,
 }
 
 impl App {
@@ -24,7 +23,6 @@ impl App {
             cfg,
             local,
             tracker_crypto: None,
-            crypto_mode: None,
         }
     }
 
@@ -38,22 +36,14 @@ impl App {
     }
 
     pub(crate) fn get_crypto_mode(&self, requires_crypto: bool) -> Option<CryptoMode> {
-        if let Some(cs) = self.crypto_mode {
-            match (cs, requires_crypto) {
-                (CryptoMode::Fallback, true) => Some(CryptoMode::Encrypt),
-                (CryptoMode::Plain, true) => None,
-                (cs, _) => Some(cs),
-            }
-        } else {
-            match (self.cfg.peers.encryption_preference, requires_crypto) {
-                (CryptoPreference::Always, _) => Some(CryptoMode::Encrypt),
-                (CryptoPreference::Fallback, true) => Some(CryptoMode::Encrypt),
-                (CryptoPreference::Fallback, false) => Some(CryptoMode::Fallback),
-                (CryptoPreference::IfRequired, true) => Some(CryptoMode::Encrypt),
-                (CryptoPreference::IfRequired, false) => Some(CryptoMode::Plain),
-                (CryptoPreference::Never, true) => None,
-                (CryptoPreference::Never, false) => Some(CryptoMode::Plain),
-            }
+        match (self.cfg.peers.encryption_preference, requires_crypto) {
+            (CryptoPreference::Always, _) => Some(CryptoMode::Encrypt),
+            (CryptoPreference::Fallback, true) => Some(CryptoMode::Encrypt),
+            (CryptoPreference::Fallback, false) => Some(CryptoMode::Fallback),
+            (CryptoPreference::IfRequired, true) => Some(CryptoMode::Encrypt),
+            (CryptoPreference::IfRequired, false) => Some(CryptoMode::Plain),
+            (CryptoPreference::Never, true) => None,
+            (CryptoPreference::Never, false) => Some(CryptoMode::Plain),
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::consts::PEER_ID_PREFIX;
+use crate::peer::CryptoStrategy;
 use crate::tracker::TrackerCrypto;
 use crate::types::{Key, PeerId};
 use rand::Rng;
@@ -10,6 +11,7 @@ pub(crate) struct App {
     pub(crate) cfg: Config,
     pub(crate) local: LocalPeer,
     pub(crate) tracker_crypto: Option<TrackerCrypto>,
+    pub(crate) crypto_strategy: Option<CryptoStrategy>,
 }
 
 impl App {
@@ -22,11 +24,22 @@ impl App {
             cfg,
             local,
             tracker_crypto: None,
+            crypto_strategy: None,
         }
     }
 
     pub(crate) fn get_tracker_crypto(&self) -> TrackerCrypto {
         self.tracker_crypto.unwrap_or_default()
+    }
+
+    pub(crate) fn get_crypto_strategy(&self, requires_crypto: bool) -> Option<CryptoStrategy> {
+        match (self.crypto_strategy, requires_crypto) {
+            (None, true) => Some(CryptoStrategy::Always),
+            (None, false) => Some(CryptoStrategy::Fallback),
+            (Some(CryptoStrategy::Fallback), true) => Some(CryptoStrategy::Always),
+            (Some(CryptoStrategy::Never), true) => None,
+            (Some(cs), _) => Some(cs),
+        }
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,7 +21,7 @@ impl App {
     }
 
     pub(crate) fn get_crypto_mode(&self, requires_crypto: bool) -> Option<CryptoMode> {
-        match (self.cfg.peers.encryption_preference, requires_crypto) {
+        match (self.cfg.general.encrypt, requires_crypto) {
             (CryptoPreference::Always, _) => Some(CryptoMode::Encrypt),
             (CryptoPreference::Prefer, true) => Some(CryptoMode::Encrypt),
             (CryptoPreference::Prefer, false) => Some(CryptoMode::Prefer),

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,6 +113,9 @@ pub(crate) struct PeersConfig {
         deserialize_with = "deserialize_seconds"
     )]
     pub(crate) dh_exchange_timeout: Duration,
+
+    #[serde(default)]
+    pub(crate) encryption_preference: CryptoPreference,
 }
 
 impl Default for PeersConfig {
@@ -121,6 +124,7 @@ impl Default for PeersConfig {
             jobs_per_magnet: default_peer_jobs_per_magnet(),
             handshake_timeout: default_handshake_timeout(),
             dh_exchange_timeout: default_dh_exchange_timeout(),
+            encryption_preference: CryptoPreference::default(),
         }
     }
 }
@@ -242,6 +246,16 @@ impl<'de> Deserialize<'de> for LocalPort {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum CryptoPreference {
+    Always,
+    #[default]
+    Fallback,
+    IfRequired,
+    Never,
+}
+
 #[derive(Debug, Error)]
 pub(crate) enum ConfigError {
     #[error("error reading configuration file")]
@@ -315,6 +329,7 @@ mod tests {
                     jobs_per_magnet: NonZeroUsize::new(30).unwrap(),
                     handshake_timeout: Duration::from_secs(60),
                     dh_exchange_timeout: Duration::from_secs(30),
+                    encryption_preference: CryptoPreference::Fallback,
                 }
             }
         );
@@ -452,6 +467,7 @@ mod tests {
             "\n",
             "[peers]\n",
             "dh-exchange-timeout = 10\n",
+            "encryption-preference = \"if-required\"\n",
             "handshake-timeout = 120\n",
             "jobs-per-magnet = 23\n",
         ))
@@ -476,6 +492,7 @@ mod tests {
                     jobs_per_magnet: NonZeroUsize::new(23).unwrap(),
                     handshake_timeout: Duration::from_secs(120),
                     dh_exchange_timeout: Duration::from_secs(10),
+                    encryption_preference: CryptoPreference::IfRequired,
                 }
             }
         );

--- a/src/config.rs
+++ b/src/config.rs
@@ -252,7 +252,7 @@ impl<'de> Deserialize<'de> for LocalPort {
 pub(crate) enum CryptoPreference {
     Always,
     #[default]
-    Fallback,
+    Prefer,
     IfRequired,
     Never,
 }
@@ -340,7 +340,7 @@ mod tests {
                     jobs_per_magnet: NonZeroUsize::new(30).unwrap(),
                     handshake_timeout: Duration::from_secs(60),
                     dh_exchange_timeout: Duration::from_secs(30),
-                    encryption_preference: CryptoPreference::Fallback,
+                    encryption_preference: CryptoPreference::Prefer,
                 }
             }
         );

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::peer::CryptoMode;
 use crate::tracker::TrackerCrypto;
 use rand::Rng;
 use serde::{
@@ -263,6 +264,18 @@ impl CryptoPreference {
             CryptoPreference::Always => TrackerCrypto::Required,
             CryptoPreference::Never => TrackerCrypto::Plain,
             _ => TrackerCrypto::Supported,
+        }
+    }
+
+    pub(crate) fn get_crypto_mode(&self, requires_crypto: bool) -> Option<CryptoMode> {
+        match (self, requires_crypto) {
+            (CryptoPreference::Always, _) => Some(CryptoMode::Encrypt),
+            (CryptoPreference::Prefer, true) => Some(CryptoMode::Encrypt),
+            (CryptoPreference::Prefer, false) => Some(CryptoMode::Prefer),
+            (CryptoPreference::IfRequired, true) => Some(CryptoMode::Encrypt),
+            (CryptoPreference::IfRequired, false) => Some(CryptoMode::Plain),
+            (CryptoPreference::Never, true) => None,
+            (CryptoPreference::Never, false) => Some(CryptoMode::Plain),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::tracker::TrackerCrypto;
 use rand::Rng;
 use serde::{
     de::{Deserializer, Unexpected},
@@ -254,6 +255,16 @@ pub(crate) enum CryptoPreference {
     Fallback,
     IfRequired,
     Never,
+}
+
+impl CryptoPreference {
+    pub(crate) fn get_tracker_crypto(&self) -> TrackerCrypto {
+        match self {
+            CryptoPreference::Always => TrackerCrypto::Required,
+            CryptoPreference::Never => TrackerCrypto::Plain,
+            _ => TrackerCrypto::Supported,
+        }
+    }
 }
 
 #[derive(Debug, Error)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,13 @@ pub(crate) struct PeersConfig {
         deserialize_with = "deserialize_seconds"
     )]
     pub(crate) handshake_timeout: Duration,
+
+    /// Timeout for receiving packet 2 from server during encryption handshake
+    #[serde(
+        default = "default_dh_exchange_timeout",
+        deserialize_with = "deserialize_seconds"
+    )]
+    pub(crate) dh_exchange_timeout: Duration,
 }
 
 impl Default for PeersConfig {
@@ -113,6 +120,7 @@ impl Default for PeersConfig {
         PeersConfig {
             jobs_per_magnet: default_peer_jobs_per_magnet(),
             handshake_timeout: default_handshake_timeout(),
+            dh_exchange_timeout: default_dh_exchange_timeout(),
         }
     }
 }
@@ -270,6 +278,10 @@ fn default_handshake_timeout() -> Duration {
     Duration::from_secs(60)
 }
 
+fn default_dh_exchange_timeout() -> Duration {
+    crate::peer::msepe::DEFAULT_DH_EXCHANGE_TIMEOUT
+}
+
 fn deserialize_seconds<'de, D>(deserializer: D) -> Result<Duration, D::Error>
 where
     D: Deserializer<'de>,
@@ -302,6 +314,7 @@ mod tests {
                 peers: PeersConfig {
                     jobs_per_magnet: NonZeroUsize::new(30).unwrap(),
                     handshake_timeout: Duration::from_secs(60),
+                    dh_exchange_timeout: Duration::from_secs(30),
                 }
             }
         );
@@ -431,15 +444,16 @@ mod tests {
             "batch-jobs = 100\n",
             "\n",
             "[trackers]\n",
+            "announce-timeout = 45\n",
+            "jobs-per-magnet = 42\n",
             "local-port = \"10000-65535\"\n",
             "numwant = 75\n",
-            "jobs-per-magnet = 42\n",
-            "announce-timeout = 45\n",
             "shutdown-timeout = 5\n",
             "\n",
             "[peers]\n",
-            "jobs-per-magnet = 23\n",
+            "dh-exchange-timeout = 10\n",
             "handshake-timeout = 120\n",
+            "jobs-per-magnet = 23\n",
         ))
         .unwrap();
         assert_eq!(
@@ -461,6 +475,7 @@ mod tests {
                 peers: PeersConfig {
                     jobs_per_magnet: NonZeroUsize::new(23).unwrap(),
                     handshake_timeout: Duration::from_secs(120),
+                    dh_exchange_timeout: Duration::from_secs(10),
                 }
             }
         );

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,12 +42,16 @@ pub(crate) struct GeneralConfig {
     /// Maximum number of magnet links to operate on at once in batch mode
     #[serde(default = "default_batch_jobs")]
     pub(crate) batch_jobs: NonZeroUsize,
+
+    #[serde(default)]
+    pub(crate) encrypt: CryptoPreference,
 }
 
 impl Default for GeneralConfig {
     fn default() -> GeneralConfig {
         GeneralConfig {
             batch_jobs: default_batch_jobs(),
+            encrypt: CryptoPreference::default(),
         }
     }
 }
@@ -114,9 +118,6 @@ pub(crate) struct PeersConfig {
         deserialize_with = "deserialize_seconds"
     )]
     pub(crate) dh_exchange_timeout: Duration,
-
-    #[serde(default)]
-    pub(crate) encryption_preference: CryptoPreference,
 }
 
 impl Default for PeersConfig {
@@ -125,7 +126,6 @@ impl Default for PeersConfig {
             jobs_per_magnet: default_peer_jobs_per_magnet(),
             handshake_timeout: default_handshake_timeout(),
             dh_exchange_timeout: default_dh_exchange_timeout(),
-            encryption_preference: CryptoPreference::default(),
         }
     }
 }
@@ -328,6 +328,7 @@ mod tests {
             Config {
                 general: GeneralConfig {
                     batch_jobs: NonZeroUsize::new(50).unwrap(),
+                    encrypt: CryptoPreference::Prefer,
                 },
                 trackers: TrackersConfig {
                     local_port: LocalPort::default(),
@@ -340,7 +341,6 @@ mod tests {
                     jobs_per_magnet: NonZeroUsize::new(30).unwrap(),
                     handshake_timeout: Duration::from_secs(60),
                     dh_exchange_timeout: Duration::from_secs(30),
-                    encryption_preference: CryptoPreference::Prefer,
                 }
             }
         );
@@ -468,6 +468,7 @@ mod tests {
         let cfg = load_config(concat!(
             "[general]\n",
             "batch-jobs = 100\n",
+            "encrypt = \"if-required\"\n",
             "\n",
             "[trackers]\n",
             "announce-timeout = 45\n",
@@ -478,7 +479,6 @@ mod tests {
             "\n",
             "[peers]\n",
             "dh-exchange-timeout = 10\n",
-            "encryption-preference = \"if-required\"\n",
             "handshake-timeout = 120\n",
             "jobs-per-magnet = 23\n",
         ))
@@ -488,6 +488,7 @@ mod tests {
             Config {
                 general: GeneralConfig {
                     batch_jobs: NonZeroUsize::new(100).unwrap(),
+                    encrypt: CryptoPreference::IfRequired,
                 },
                 trackers: TrackersConfig {
                     local_port: LocalPort::Range {
@@ -503,7 +504,6 @@ mod tests {
                     jobs_per_magnet: NonZeroUsize::new(23).unwrap(),
                     handshake_timeout: Duration::from_secs(120),
                     dh_exchange_timeout: Duration::from_secs(10),
-                    encryption_preference: CryptoPreference::IfRequired,
                 }
             }
         );

--- a/src/magnet.rs
+++ b/src/magnet.rs
@@ -48,7 +48,7 @@ impl Magnet {
                 let group = Arc::clone(&shutdown_group);
                 let display = self.to_string();
                 async move {
-                    match tracker.get_peers(info_hash, app, group).await {
+                    match tracker.peer_getter(info_hash, app, group).run().await {
                         Ok(peers) => iter(peers),
                         Err(e) => {
                             log::warn!(

--- a/src/magnet.rs
+++ b/src/magnet.rs
@@ -1,5 +1,5 @@
 use crate::app::App;
-use crate::asyncutil::{BufferedTasks, ShutdownGroup, UniqueExt};
+use crate::asyncutil::{BufferedTasks, ShutdownGroup, UniqueByExt};
 use crate::torrent::{PathTemplate, TorrentFile};
 use crate::tracker::{Tracker, TrackerUrlError};
 use crate::types::{InfoHash, InfoHashError};
@@ -64,7 +64,9 @@ impl Magnet {
             }),
         )
         .flatten()
-        .unique();
+        // Weed out duplicate peers, ignoring differences in peer IDs and
+        // requires_crypto fields … for now:
+        .unique_by(|peer| peer.address);
         let (sender, mut receiver) = channel(app.cfg.peers.jobs_per_magnet.get());
         let peer_job = tokio::spawn(async move {
             let peer_tasks = BufferedTasks::from_stream(

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,7 @@ enum Command {
         /// Attempt to create an encrypted connection to the peer; if that
         /// fails, try again without encryption
         #[arg(long, conflicts_with = "encrypt", conflicts_with = "no_encrypt")]
-        try_encrypt: bool,
+        prefer_encrypt: bool,
 
         /// The peer to get metadata from, in the form "IP:PORT" (or
         /// "[IP]:PORT" for IPv6).
@@ -307,12 +307,12 @@ impl Command {
                 peer,
                 info_hash,
                 encrypt,
-                try_encrypt,
+                prefer_encrypt,
                 no_encrypt,
             } => {
-                let crypto_mode = match (encrypt, try_encrypt, no_encrypt) {
+                let crypto_mode = match (encrypt, prefer_encrypt, no_encrypt) {
                     (true, _, _) => Some(CryptoMode::Encrypt),
-                    (false, true, _) => Some(CryptoMode::Fallback),
+                    (false, true, _) => Some(CryptoMode::Prefer),
                     (false, false, true) => Some(CryptoMode::Plain),
                     (false, false, false) => None,
                 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,8 +318,12 @@ impl Command {
                     (false, false, true) => Some(CryptoMode::Plain),
                     (false, false, false) => None,
                 };
-                app.crypto_mode = crypto_mode;
-                match peer.info_getter(info_hash, Arc::new(app)).run().await {
+                match peer
+                    .info_getter(info_hash, Arc::new(app))
+                    .crypto_mode(crypto_mode)
+                    .run()
+                    .await
+                {
                     Ok(info) => {
                         let tf = TorrentFile::new(info, Vec::new());
                         if let Err(e) = tf.save(&outfile).await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use crate::app::App;
 use crate::asyncutil::{BufferedTasks, ShutdownGroup};
 use crate::config::{Config, ConfigError};
 use crate::magnet::{parse_magnets_file, Magnet};
-use crate::peer::{CryptoStrategy, Peer};
+use crate::peer::{CryptoMode, Peer};
 use crate::torrent::{PathTemplate, TorrentFile};
 use crate::tracker::{Tracker, TrackerCrypto};
 use crate::types::InfoHash;
@@ -312,13 +312,13 @@ impl Command {
                 try_encrypt,
                 no_encrypt,
             } => {
-                let crypto_strategy = match (encrypt, try_encrypt, no_encrypt) {
-                    (true, _, _) => Some(CryptoStrategy::Always),
-                    (false, true, _) => Some(CryptoStrategy::Fallback),
-                    (false, false, true) => Some(CryptoStrategy::Never),
+                let crypto_mode = match (encrypt, try_encrypt, no_encrypt) {
+                    (true, _, _) => Some(CryptoMode::Encrypt),
+                    (false, true, _) => Some(CryptoMode::Fallback),
+                    (false, false, true) => Some(CryptoMode::Plain),
                     (false, false, false) => None,
                 };
-                app.crypto_strategy = crypto_strategy;
+                app.crypto_mode = crypto_mode;
                 match peer.info_getter(info_hash, Arc::new(app)).run().await {
                     Ok(info) => {
                         let tf = TorrentFile::new(info, Vec::new());

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -232,6 +232,7 @@ impl<'a> InfoGetter<'a> {
             registry
         };
         let msg = Message::from(ExtendedHandshake {
+            e: None,
             m: Some(local_registry.to_m()),
             v: Some(CLIENT.into()),
             metadata_size: None,

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod extensions;
 mod messages;
-mod msepe;
+pub(crate) mod msepe;
 use self::extensions::*;
 use self::messages::*;
 use crate::app::App;
@@ -190,7 +190,8 @@ impl<'a> InfoGetter<'a> {
                 log::debug!("Encrypting connection to {} ...", self.peer);
                 match msepe::EncryptedStream::handshake(
                     inner,
-                    msepe::HandshakeBuilder::new(*self.peer, self.info_hash, StdRng::from_os_rng()),
+                    msepe::HandshakeBuilder::new(*self.peer, self.info_hash, StdRng::from_os_rng())
+                        .dh_exchange_timeout(self.app.cfg.peers.dh_exchange_timeout),
                 )
                 .await
                 {

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod extensions;
 mod messages;
+mod msepe;
 use self::extensions::*;
 use self::messages::*;
 use crate::app::App;
@@ -22,7 +23,7 @@ use tokio_util::codec::{
     Framed,
 };
 
-#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub(crate) struct Peer {
     pub(crate) address: SocketAddr,
     pub(crate) id: Option<PeerId>,
@@ -361,6 +362,8 @@ pub(crate) enum PeerError {
     Disconnect,
     #[error(transparent)]
     Handshake(#[from] HandshakeError),
+    #[error(transparent)]
+    CryptoHandshake(#[from] msepe::HandshakeError),
     #[error("peer sent invalid message")]
     Message(#[from] MessageError),
     #[error("peer sent extended handshake with inconsistent \"m\" dict")]

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -195,7 +195,10 @@ impl<'a> InfoGetter<'a> {
                 .await
                 {
                     Ok(s) => Either::Right(s),
-                    Err(e) if crypto_strategy == CryptoStrategy::Fallback => {
+                    Err(e)
+                        if crypto_strategy == CryptoStrategy::Fallback
+                            && !self.peer.requires_crypto =>
+                    {
                         log::warn!("Encryption handshake with {} failed: {}; will try unencrypted connection", self.peer, ErrorChain(e));
                         Either::Left(self.tcp_connect().await?)
                     }

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -470,7 +470,15 @@ impl fmt::Display for DisplayJson<'_> {
         } else {
             write!(f, "null")?;
         }
-        f.write_char('}')?;
+        write!(
+            f,
+            r#", "requires_crypto": {}}}"#,
+            if self.0.requires_crypto {
+                "true"
+            } else {
+                "false"
+            }
+        )?;
         Ok(())
     }
 }
@@ -570,7 +578,10 @@ mod tests {
         fn no_id() {
             let peer = "127.0.0.1:8080".parse::<Peer>().unwrap();
             let s = peer.display_json().to_string();
-            assert_eq!(s, r#"{"host": "127.0.0.1", "port": 8080, "id": null}"#);
+            assert_eq!(
+                s,
+                r#"{"host": "127.0.0.1", "port": 8080, "id": null, "requires_crypto": false}"#
+            );
         }
 
         #[test]
@@ -582,7 +593,7 @@ mod tests {
             let s = peer.display_json().to_string();
             assert_eq!(
                 s,
-                r#"{"host": "127.0.0.1", "port": 8080, "id": "-PRE-123-abcdefghijk"}"#
+                r#"{"host": "127.0.0.1", "port": 8080, "id": "-PRE-123-abcdefghijk", "requires_crypto": false}"#
             );
         }
 
@@ -595,7 +606,7 @@ mod tests {
             let s = peer.display_json().to_string();
             assert_eq!(
                 s,
-                r#"{"host": "127.0.0.1", "port": 8080, "id": "-PRE-123-abcdefgh\u00eej"}"#
+                r#"{"host": "127.0.0.1", "port": 8080, "id": "-PRE-123-abcdefgh\u00eej", "requires_crypto": false}"#
             );
         }
 
@@ -608,7 +619,21 @@ mod tests {
             let s = peer.display_json().to_string();
             assert_eq!(
                 s,
-                r#"{"host": "127.0.0.1", "port": 8080, "id": "-PRE-123-abcdefgh\ufffdjk"}"#
+                r#"{"host": "127.0.0.1", "port": 8080, "id": "-PRE-123-abcdefgh\ufffdjk", "requires_crypto": false}"#
+            );
+        }
+
+        #[test]
+        fn requires_crypto() {
+            let peer = Peer {
+                address: "127.0.0.1:8080".parse::<SocketAddr>().unwrap(),
+                id: None,
+                requires_crypto: true,
+            };
+            let s = peer.display_json().to_string();
+            assert_eq!(
+                s,
+                r#"{"host": "127.0.0.1", "port": 8080, "id": null, "requires_crypto": true}"#
             );
         }
     }

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -41,6 +41,7 @@ pub(crate) enum CryptoStrategy {
 pub(crate) struct Peer {
     pub(crate) address: SocketAddr,
     pub(crate) id: Option<PeerId>,
+    pub(crate) requires_crypto: bool,
 }
 
 impl Peer {
@@ -63,7 +64,11 @@ impl FromStr for Peer {
 
     fn from_str(s: &str) -> Result<Peer, AddrParseError> {
         let address = s.parse::<SocketAddr>()?;
-        Ok(Peer { address, id: None })
+        Ok(Peer {
+            address,
+            id: None,
+            requires_crypto: false,
+        })
     }
 }
 
@@ -78,6 +83,7 @@ impl From<SocketAddrV4> for Peer {
         Peer {
             address: addr.into(),
             id: None,
+            requires_crypto: false,
         }
     }
 }
@@ -87,6 +93,7 @@ impl From<SocketAddrV6> for Peer {
         Peer {
             address: addr.into(),
             id: None,
+            requires_crypto: false,
         }
     }
 }
@@ -142,6 +149,7 @@ impl FromBencode for Peer {
         Ok(Peer {
             address: SocketAddr::new(ip, port),
             id: peer_id,
+            requires_crypto: false,
         })
     }
 }

--- a/src/peer/msepe.rs
+++ b/src/peer/msepe.rs
@@ -568,10 +568,96 @@ fn biguint2bytes(bi: &BigUint) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha12Rng;
 
     #[test]
     fn test_prime_modulus() {
         // Test that it doesn't panic
         let _ = prime_modulus();
+    }
+
+    #[test]
+    fn test_build_handshaker() {
+        let peer = "127.0.0.1:60069".parse::<Peer>().unwrap();
+        let info_hash = "28C55196F57753C40ACEB6FB58617E6995A7EDDB"
+            .parse::<InfoHash>()
+            .unwrap();
+        let builder = HandshakeBuilder::new(
+            peer,
+            info_hash,
+            ChaCha12Rng::seed_from_u64(0x0123456789ABCDEF),
+        );
+        let shaker = builder.build();
+        assert_eq!(shaker.peer, peer);
+        let HandshakeState::Packet2 { private_key } = shaker.state else {
+            panic!("Handshaker state is not Packet2");
+        };
+        assert_eq!(
+            private_key,
+            BigUint::parse_bytes(b"a068078feb542e953c13e4dacece2b6730a2b512".as_slice(), 16)
+                .unwrap()
+        );
+        let mut packet1 = BytesMut::new();
+        packet1.put(b"\xfe\x0f\xfe\xfc\x8aU\x94|pTr\x92W\xd3a\xde".as_slice());
+        packet1.put(b"\xff\xc0\xf25\xbd\x04\x01\xac\xf2\x83\xc4".as_slice());
+        packet1.put(b"\xa3M\r8\xb7\xfc\x18?\xc4\xb1r\xe7N\xed\"&".as_slice());
+        packet1.put(b"\xc9\xb5\x837`TH\xb8!z\x03kt\x08\x86\xc4".as_slice());
+        packet1.put(b"\x95x\x96<\x8e\xf1\xe1!\x1d\xa9O>\x13\x86".as_slice());
+        packet1.put(b"\xa9\xa6\xf8.\x8eT\x15m\xe0\xfcX\x97\xb3".as_slice());
+        packet1.put(b"\xa8Jm\x81\x08I,\xc3\x8bjr\xca\x1a\xf2'b".as_slice());
+        packet1.put(b"\xf1\"\x8a\xbc,\xe2\0\xc8\xe7\x90\xf6\xc4".as_slice());
+        packet1.put(b"\x81\x1c\xda\xab\x9d\xb4\xf5\xe4}\xd5\xd0".as_slice());
+        packet1.put(b"\x98q~\xef]\x13\xf9\x07\x97\x15'C\x06\x0fUR".as_slice());
+        packet1.put(b"\xb7=\xc9\x9f\x9d\x89\xc5:\x0fU\xe1s\xa76".as_slice());
+        packet1.put(b"\xb0\xc1\x11\x0b\xb3\xf3T_\xa2\xbbM\x19A".as_slice());
+        packet1.put(b"\xab\xd1\xe2\"\xff\xbf\x07X\xa9\xfb\xf3\x0c".as_slice());
+        packet1.put(b"\xca\"u\xc2\xb3\x86\xa1\xf2u\"X\xafy \x01".as_slice());
+        packet1.put(b"\x18\xe8\xc2\xb3\x1fh\x91\xd8\xb2{\xc8\x08".as_slice());
+        packet1.put(b"\xd700*\xea#\x1d\x88p\xdf_\xc0L\x06\xb6wn".as_slice());
+        packet1.put(b"\xadD+r\x11T\x9e*%\xeaT\xe4\x7f\x1f(\x93".as_slice());
+        packet1.put(b"\x1dzn\x9a-\xff\xfaE\x83\x98\xd1\xc3\xacC".as_slice());
+        packet1.put(b"\xd9\x9b)\xee&\xcf\xcf\r\xe2\xbf\x9c\xe2".as_slice());
+        packet1.put(b"\xedgJ\x87\x1c8\xf9\x175\x0f\n\xa4\xf5c$H".as_slice());
+        packet1.put(b"\xf2ak&\xc8\xad\x01\xf9\xd5\x87\xea\x1f\xcc".as_slice());
+        packet1.put(b"<\xf3aN\xd9U/\xd1\xed\xcbT9dY+\x066\x14\xd3".as_slice());
+        packet1.put(b"b\xe8\xa2\x90h(\x1a\xa2A\xefj\t\x90p\xdfd\x03".as_slice());
+        packet1.put(b"\x92W\x99\xb3\xd2!\xd5\n\xe2W\xfd\xef\xf2\xf5".as_slice());
+        packet1.put(b"\x92\xbc\xe2%v\xa6J\xcfv@9m\x8br0\xcagV=\x9d&".as_slice());
+        packet1.put(b"\xce\x1fF*\rGD\xa8\xf61\xd0[E\xf2\x8c;^\x16f_".as_slice());
+        packet1.put(b"k+\xfdF\xe3\xbcS\x07\x91N\x94\"\xae\xb5V\xedG".as_slice());
+        packet1.put(b"\x13\xb9\xec\xb0\0]^A\xfd\x94\xef\xbc\x7fk".as_slice());
+        packet1.put(b"\x7f\xe0\x93f:k\x85\xbb\x13xo\x16v\xf4\x15".as_slice());
+        packet1.put(b"\x1b\"U.XM\\\xfb\xe0\xf7\x13\xb9\xdc\r)\xf8;".as_slice());
+        packet1.put(b"\xdb\x0b\xd8\xb1\xc8f\x06\xd5\xa5EH\xe1<v\x02".as_slice());
+        packet1.put(b"\x96\xc3\xf0\xe6\xfd\xc5\xf1-\xf9^\xf3`\x1b".as_slice());
+        packet1.put(b"\xf9\x16(\xe5\x0ev\xf9\r\xaaK\xb3e\xbd\xca".as_slice());
+        packet1.put(b"\x0c\xe5\x1f\x81\x91\xda`\x97k\x88\xc5\xc4".as_slice());
+        packet1.put(b"\x97\x8e".as_slice());
+        assert_eq!(shaker.output_packet, Some(packet1.freeze()));
+        assert_eq!(shaker.padc_len, 379);
+        assert_eq!(shaker.skey, info_hash);
+        assert_eq!(shaker.timeout, Some(DEFAULT_DH_EXCHANGE_TIMEOUT));
+        assert_eq!(shaker.input_buffer, BytesMut::new());
+        assert_eq!(
+            shaker.crypto_provide,
+            CryptoMethodSet::from_iter(DEFAULT_CRYPTO_PROVIDE)
+        );
+    }
+
+    #[test]
+    fn test_build_handshaker_custom_timeout() {
+        let peer = "127.0.0.1:60069".parse::<Peer>().unwrap();
+        let info_hash = "28C55196F57753C40ACEB6FB58617E6995A7EDDB"
+            .parse::<InfoHash>()
+            .unwrap();
+        let builder = HandshakeBuilder::new(
+            peer,
+            info_hash,
+            ChaCha12Rng::seed_from_u64(0x0123456789ABCDEF),
+        )
+        .dh_exchange_timeout(Duration::from_secs(5));
+        let shaker = builder.build();
+        assert_eq!(shaker.timeout, Some(Duration::from_secs(5)));
     }
 }

--- a/src/peer/msepe.rs
+++ b/src/peer/msepe.rs
@@ -598,43 +598,13 @@ mod tests {
             BigUint::parse_bytes(b"a068078feb542e953c13e4dacece2b6730a2b512".as_slice(), 16)
                 .unwrap()
         );
-        let mut packet1 = BytesMut::new();
-        packet1.put(b"\xfe\x0f\xfe\xfc\x8aU\x94|pTr\x92W\xd3a\xde".as_slice());
-        packet1.put(b"\xff\xc0\xf25\xbd\x04\x01\xac\xf2\x83\xc4".as_slice());
-        packet1.put(b"\xa3M\r8\xb7\xfc\x18?\xc4\xb1r\xe7N\xed\"&".as_slice());
-        packet1.put(b"\xc9\xb5\x837`TH\xb8!z\x03kt\x08\x86\xc4".as_slice());
-        packet1.put(b"\x95x\x96<\x8e\xf1\xe1!\x1d\xa9O>\x13\x86".as_slice());
-        packet1.put(b"\xa9\xa6\xf8.\x8eT\x15m\xe0\xfcX\x97\xb3".as_slice());
-        packet1.put(b"\xa8Jm\x81\x08I,\xc3\x8bjr\xca\x1a\xf2'b".as_slice());
-        packet1.put(b"\xf1\"\x8a\xbc,\xe2\0\xc8\xe7\x90\xf6\xc4".as_slice());
-        packet1.put(b"\x81\x1c\xda\xab\x9d\xb4\xf5\xe4}\xd5\xd0".as_slice());
-        packet1.put(b"\x98q~\xef]\x13\xf9\x07\x97\x15'C\x06\x0fUR".as_slice());
-        packet1.put(b"\xb7=\xc9\x9f\x9d\x89\xc5:\x0fU\xe1s\xa76".as_slice());
-        packet1.put(b"\xb0\xc1\x11\x0b\xb3\xf3T_\xa2\xbbM\x19A".as_slice());
-        packet1.put(b"\xab\xd1\xe2\"\xff\xbf\x07X\xa9\xfb\xf3\x0c".as_slice());
-        packet1.put(b"\xca\"u\xc2\xb3\x86\xa1\xf2u\"X\xafy \x01".as_slice());
-        packet1.put(b"\x18\xe8\xc2\xb3\x1fh\x91\xd8\xb2{\xc8\x08".as_slice());
-        packet1.put(b"\xd700*\xea#\x1d\x88p\xdf_\xc0L\x06\xb6wn".as_slice());
-        packet1.put(b"\xadD+r\x11T\x9e*%\xeaT\xe4\x7f\x1f(\x93".as_slice());
-        packet1.put(b"\x1dzn\x9a-\xff\xfaE\x83\x98\xd1\xc3\xacC".as_slice());
-        packet1.put(b"\xd9\x9b)\xee&\xcf\xcf\r\xe2\xbf\x9c\xe2".as_slice());
-        packet1.put(b"\xedgJ\x87\x1c8\xf9\x175\x0f\n\xa4\xf5c$H".as_slice());
-        packet1.put(b"\xf2ak&\xc8\xad\x01\xf9\xd5\x87\xea\x1f\xcc".as_slice());
-        packet1.put(b"<\xf3aN\xd9U/\xd1\xed\xcbT9dY+\x066\x14\xd3".as_slice());
-        packet1.put(b"b\xe8\xa2\x90h(\x1a\xa2A\xefj\t\x90p\xdfd\x03".as_slice());
-        packet1.put(b"\x92W\x99\xb3\xd2!\xd5\n\xe2W\xfd\xef\xf2\xf5".as_slice());
-        packet1.put(b"\x92\xbc\xe2%v\xa6J\xcfv@9m\x8br0\xcagV=\x9d&".as_slice());
-        packet1.put(b"\xce\x1fF*\rGD\xa8\xf61\xd0[E\xf2\x8c;^\x16f_".as_slice());
-        packet1.put(b"k+\xfdF\xe3\xbcS\x07\x91N\x94\"\xae\xb5V\xedG".as_slice());
-        packet1.put(b"\x13\xb9\xec\xb0\0]^A\xfd\x94\xef\xbc\x7fk".as_slice());
-        packet1.put(b"\x7f\xe0\x93f:k\x85\xbb\x13xo\x16v\xf4\x15".as_slice());
-        packet1.put(b"\x1b\"U.XM\\\xfb\xe0\xf7\x13\xb9\xdc\r)\xf8;".as_slice());
-        packet1.put(b"\xdb\x0b\xd8\xb1\xc8f\x06\xd5\xa5EH\xe1<v\x02".as_slice());
-        packet1.put(b"\x96\xc3\xf0\xe6\xfd\xc5\xf1-\xf9^\xf3`\x1b".as_slice());
-        packet1.put(b"\xf9\x16(\xe5\x0ev\xf9\r\xaaK\xb3e\xbd\xca".as_slice());
-        packet1.put(b"\x0c\xe5\x1f\x81\x91\xda`\x97k\x88\xc5\xc4".as_slice());
-        packet1.put(b"\x97\x8e".as_slice());
-        assert_eq!(shaker.output_packet, Some(packet1.freeze()));
+        let packet1 = shaker.output_packet.unwrap();
+        let pubkey = BigUint::from_bytes_be(&packet1[..MODULUS_BYTES]);
+        assert_eq!(
+            pubkey,
+            BigUint::from(2usize).modpow(&private_key, &prime_modulus())
+        );
+        assert!(((MODULUS_BYTES)..(MODULUS_BYTES + 512)).contains(&packet1.len()));
         assert_eq!(shaker.padc_len, 379);
         assert_eq!(shaker.skey, info_hash);
         assert_eq!(shaker.timeout, Some(DEFAULT_DH_EXCHANGE_TIMEOUT));

--- a/src/peer/msepe.rs
+++ b/src/peer/msepe.rs
@@ -448,6 +448,7 @@ impl EncryptedStream {
                         "Finished receiving encryption handshake packet 2 from {}",
                         handshaker.peer
                     );
+                    timeout_time = None;
                     handshaker.handle_timeout()?;
                 }
             }

--- a/src/peer/msepe.rs
+++ b/src/peer/msepe.rs
@@ -78,6 +78,7 @@ impl<R: Rng> HandshakeBuilder<R> {
         }
     }
 
+    /*
     pub(super) fn crypto_provide<I: IntoIterator<Item = CryptoMethod>>(
         mut self,
         methods: I,
@@ -85,13 +86,15 @@ impl<R: Rng> HandshakeBuilder<R> {
         self.crypto_provide = CryptoMethodSet::from_iter(methods);
         self
     }
+    */
 
+    #[expect(unused)]
     pub(super) fn timeout(mut self, d: Duration) -> Self {
         self.timeout = d;
         self
     }
 
-    pub(super) fn build(self) -> Handshaker {
+    fn build(self) -> Handshaker {
         let mut rng = self.rng;
         let pada_len = rng.random_range(..=512);
         let padc_len = rng.random_range(..=512);
@@ -113,7 +116,7 @@ impl<R: Rng> HandshakeBuilder<R> {
     }
 }
 
-pub(super) struct Handshaker {
+struct Handshaker {
     peer: Peer,
     state: HandshakeState,
     output_packet: Option<Bytes>,
@@ -355,6 +358,7 @@ pub(crate) enum HandshakeError {
 }
 
 #[derive(Default)]
+#[allow(clippy::large_enum_variant)]
 enum Keystream {
     #[default]
     Plaintext,
@@ -366,6 +370,7 @@ enum Keystream {
 
 impl Keystream {
     /// Encode data before sending it to the server
+    #[expect(unused)]
     fn encode(&mut self, bs: &mut [u8]) {
         if let Keystream::Rc4 {
             ref mut outgoing, ..
@@ -387,7 +392,7 @@ impl Keystream {
 }
 
 pin_project_lite::pin_project! {
-    struct EncryptedStream {
+    pub(super) struct EncryptedStream {
         #[pin]
         inner: TcpStream,
         keystream: Keystream,
@@ -474,6 +479,7 @@ impl AsyncRead for EncryptedStream {
 }
 
 impl AsyncWrite for EncryptedStream {
+    #[expect(unused)]
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,

--- a/src/peer/msepe.rs
+++ b/src/peer/msepe.rs
@@ -17,7 +17,7 @@ use tokio::{
     time::{timeout_at, Instant},
 };
 
-const DEFAULT_PACKET2_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const DEFAULT_DH_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(30);
 
 const DEFAULT_CRYPTO_PROVIDE: [CryptoMethod; 1] = [CryptoMethod::Rc4];
 
@@ -74,7 +74,7 @@ impl<R: Rng> HandshakeBuilder<R> {
             skey,
             rng,
             crypto_provide: CryptoMethodSet::from_iter(DEFAULT_CRYPTO_PROVIDE),
-            timeout: DEFAULT_PACKET2_TIMEOUT,
+            timeout: DEFAULT_DH_EXCHANGE_TIMEOUT,
         }
     }
 
@@ -88,8 +88,7 @@ impl<R: Rng> HandshakeBuilder<R> {
     }
     */
 
-    #[expect(unused)]
-    pub(super) fn timeout(mut self, d: Duration) -> Self {
+    pub(super) fn dh_exchange_timeout(mut self, d: Duration) -> Self {
         self.timeout = d;
         self
     }

--- a/src/peer/msepe.rs
+++ b/src/peer/msepe.rs
@@ -1,0 +1,546 @@
+use super::{Peer, PeerError};
+use crate::types::InfoHash;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use generic_array::GenericArray;
+use num_bigint::BigUint;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use rand::Rng;
+use rc4::{consts::U20, KeyInit, Rc4, StreamCipher};
+use sha1::{Digest, Sha1};
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
+use std::time::Duration;
+use thiserror::Error;
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf},
+    net::TcpStream,
+    time::{timeout_at, Instant},
+};
+
+const DEFAULT_PACKET2_TIMEOUT: Duration = Duration::from_secs(30);
+
+const DEFAULT_CRYPTO_PROVIDE: [CryptoMethod; 1] = [CryptoMethod::Rc4];
+
+const MODULUS_BYTES: usize = 96;
+
+const MIN_PACKET2_LEN: usize = MODULUS_BYTES;
+
+const MAX_PACKET2_LEN: usize = 608;
+
+#[derive(
+    Clone, Copy, Debug, Eq, Hash, IntoPrimitive, Ord, PartialEq, PartialOrd, TryFromPrimitive,
+)]
+#[repr(u32)]
+pub(crate) enum CryptoMethod {
+    Plaintext = 0x01,
+    Rc4 = 0x02,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct CryptoMethodSet(u32);
+
+impl CryptoMethodSet {
+    fn contains(&self, method: CryptoMethod) -> bool {
+        self.0 & u32::from(method) != 0
+    }
+}
+
+impl FromIterator<CryptoMethod> for CryptoMethodSet {
+    fn from_iter<I: IntoIterator<Item = CryptoMethod>>(iter: I) -> CryptoMethodSet {
+        let ored = iter.into_iter().fold(0u32, |acc, m| acc | u32::from(m));
+        CryptoMethodSet(ored)
+    }
+}
+
+impl From<CryptoMethodSet> for u32 {
+    fn from(value: CryptoMethodSet) -> u32 {
+        value.0
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct HandshakeBuilder<R> {
+    peer: Peer,
+    skey: InfoHash,
+    rng: R,
+    crypto_provide: CryptoMethodSet,
+    timeout: Duration,
+}
+
+impl<R: Rng> HandshakeBuilder<R> {
+    pub(super) fn new(peer: Peer, skey: InfoHash, rng: R) -> Self {
+        HandshakeBuilder {
+            peer,
+            skey,
+            rng,
+            crypto_provide: CryptoMethodSet::from_iter(DEFAULT_CRYPTO_PROVIDE),
+            timeout: DEFAULT_PACKET2_TIMEOUT,
+        }
+    }
+
+    pub(super) fn crypto_provide<I: IntoIterator<Item = CryptoMethod>>(
+        mut self,
+        methods: I,
+    ) -> Self {
+        self.crypto_provide = CryptoMethodSet::from_iter(methods);
+        self
+    }
+
+    pub(super) fn timeout(mut self, d: Duration) -> Self {
+        self.timeout = d;
+        self
+    }
+
+    pub(super) fn build(self) -> Handshaker {
+        let mut rng = self.rng;
+        let pada_len = rng.random_range(..=512);
+        let padc_len = rng.random_range(..=512);
+        let private_key = gen_private_key(&mut rng);
+        let pubkey = BigUint::from(2usize).modpow(&private_key, &prime_modulus());
+        let mut packet1 = BytesMut::with_capacity(MODULUS_BYTES + pada_len);
+        packet1.extend(biguint2bytes(&pubkey));
+        packet1.extend(rng.random_iter::<u8>().take(pada_len));
+        Handshaker {
+            peer: self.peer,
+            state: HandshakeState::Packet2 { private_key },
+            output_packet: Some(packet1.freeze()),
+            padc_len,
+            skey: self.skey,
+            timeout: Some(self.timeout),
+            input_buffer: BytesMut::new(),
+            crypto_provide: self.crypto_provide,
+        }
+    }
+}
+
+pub(super) struct Handshaker {
+    peer: Peer,
+    state: HandshakeState,
+    output_packet: Option<Bytes>,
+    padc_len: u16,
+    skey: InfoHash,
+    timeout: Option<Duration>,
+    input_buffer: BytesMut,
+    crypto_provide: CryptoMethodSet,
+}
+
+impl Handshaker {
+    /// Returns bytes to send to the server
+    ///
+    /// - On first call: Returns packet 1
+    /// - On next call after `handle_timeout()` is called: Returns packet 3
+    fn get_output(&mut self) -> Option<Bytes> {
+        self.output_packet.take()
+    }
+
+    /// Passed bytes received from the server
+    fn handle_input(&mut self, b: Bytes) -> Result<(), HandshakeError> {
+        self.input_buffer.extend(b);
+        if let HandshakeState::Packet4 {
+            substate,
+            rc4_keystream,
+        } = &mut self.state
+        {
+            loop {
+                match (&mut *substate, self.input_buffer.len()) {
+                    (Packet4State::Vc, 0..8) => break,
+                    (Packet4State::Vc, _) => {
+                        let mut vc = self.input_buffer.split_to(8);
+                        rc4_keystream.decode(vc.as_mut());
+                        if !vc.into_iter().all(|b| b == 0) {
+                            return Err(HandshakeError::VcNotZero);
+                        }
+                        *substate = Packet4State::Select;
+                    }
+                    (Packet4State::Select, 0..4) => break,
+                    (Packet4State::Select, _) => {
+                        let cs = self.input_buffer.split_to(4).get_u32();
+                        let selections = cs.count_ones();
+                        if selections != 1 {
+                            return Err(HandshakeError::SelectNotSingle(selections));
+                        }
+                        let Ok(crypto_select) = CryptoMethod::try_from(cs) else {
+                            return Err(HandshakeError::UnknownMethod(cs));
+                        };
+                        if !self.crypto_provide.contains(crypto_select) {
+                            return Err(HandshakeError::UnexpectedSelection(crypto_select));
+                        }
+                        log::trace!("{} selected encryption method {crypto_select:?}", self.peer);
+                        *substate = Packet4State::LenPadD { crypto_select };
+                    }
+                    (Packet4State::LenPadD { .. }, 0..2) => break,
+                    (Packet4State::LenPadD { crypto_select }, _) => {
+                        let bytes_needed = usize::from(self.input_buffer.split_to(2).get_u16());
+                        *substate = Packet4State::PadD {
+                            crypto_select: *crypto_select,
+                            bytes_needed,
+                        };
+                    }
+                    (
+                        Packet4State::PadD {
+                            bytes_needed,
+                            crypto_select,
+                        },
+                        bytes_avail,
+                    ) => {
+                        let sz = (*bytes_needed).min(bytes_avail);
+                        let _padd = self.input_buffer.split_to(sz);
+                        *bytes_needed -= sz;
+                        if *bytes_needed == 0 {
+                            let keystream = match crypto_select {
+                                CryptoMethod::Plaintext => Keystream::Plaintext,
+                                CryptoMethod::Rc4 => std::mem::take(rc4_keystream),
+                            };
+                            log::debug!("Encryption handshake with {} complete", self.peer);
+                            self.state = HandshakeState::Done { keystream };
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns the amount of time after which `handle_timeout()` should be called; only returns `Some` on first call
+    fn get_timeout(&mut self) -> Option<Duration> {
+        self.timeout.take()
+    }
+
+    /// Called once the timeout from `get_timeout()` has expired, thereby
+    /// indicating that the receipt of packet 2 is complete
+    fn handle_timeout(&mut self) -> Result<(), HandshakeError> {
+        if let HandshakeState::Packet2 { ref private_key } = self.state {
+            let mut packet2 = std::mem::take(&mut self.input_buffer);
+            let sz = packet2.len();
+            if !(MIN_PACKET2_LEN..=MAX_PACKET2_LEN).contains(&sz) {
+                return Err(HandshakeError::Packet2Len(sz));
+            }
+            packet2.truncate(MODULUS_BYTES);
+            let server_pubkey = BigUint::from_bytes_be(packet2.as_ref());
+            let shared_secret = server_pubkey.modpow(private_key, &prime_modulus());
+            let shared_secret = biguint2bytes(&shared_secret);
+            // TODO: Securely discard private_key
+
+            let mut key_a = BytesMut::with_capacity(4 + MODULUS_BYTES + InfoHash::LENGTH);
+            key_a.extend_from_slice(b"keyA");
+            key_a.extend_from_slice(&shared_secret);
+            key_a.extend_from_slice(self.skey.as_bytes());
+            let hash_a = hash(key_a);
+
+            let mut key_b = BytesMut::with_capacity(4 + MODULUS_BYTES + InfoHash::LENGTH);
+            key_b.extend_from_slice(b"keyB");
+            key_b.extend_from_slice(&shared_secret);
+            key_b.extend_from_slice(self.skey.as_bytes());
+            let hash_b = hash(key_b);
+
+            let mut rc4_outgoing = Rc4::new(&hash_a);
+            let mut rc4_incoming = Rc4::new(&hash_b);
+            let mut deadhead = vec![0u8; 1024];
+            // Discard first 1024 bytes of each keystream:
+            rc4_outgoing.apply_keystream(&mut deadhead);
+            rc4_incoming.apply_keystream(&mut deadhead);
+
+            /*
+            let IA = b"";
+            let VC = b"\0" * 8;
+            let packet3 =
+                HASH("req1" + shared_secret)
+                + (HASH("req2" + skey) XOR HASH("req3" + shared_secret))
+                + RC4(VC + crypto_provide + len(PadC) + PadC + len(IA) + IA)
+            */
+
+            let padc_usize = usize::from(self.padc_len);
+            let mut packet3 = BytesMut::with_capacity(20 + 20 + 8 + 4 + 2 + padc_usize + 2);
+
+            let mut req1 = BytesMut::with_capacity(4 + MODULUS_BYTES);
+            req1.extend_from_slice(b"req1");
+            req1.extend_from_slice(&shared_secret);
+            packet3.extend(hash(req1));
+
+            let mut req2 = BytesMut::with_capacity(4 + InfoHash::LENGTH);
+            req2.extend_from_slice(b"req2");
+            req2.extend_from_slice(self.skey.as_bytes());
+            let hash2 = hash(req2);
+
+            let mut req3 = BytesMut::with_capacity(4 + MODULUS_BYTES);
+            req3.extend_from_slice(b"req3");
+            req3.extend_from_slice(&shared_secret);
+            let hash3 = hash(req3);
+
+            packet3.extend(std::iter::zip(hash2, hash3).map(|(a, b)| a ^ b));
+
+            let mut outgoing = BytesMut::with_capacity(8 + 4 + 2 + padc_usize + 2);
+            outgoing.put_bytes(0, 8);
+            outgoing.put_u32(self.crypto_provide.into());
+            outgoing.put_u16(self.padc_len);
+            outgoing.put_bytes(0, padc_usize);
+            outgoing.put_u16(0);
+            rc4_outgoing.apply_keystream(&mut outgoing);
+            packet3.extend(outgoing);
+
+            self.output_packet = Some(packet3.freeze());
+            self.state = HandshakeState::Packet4 {
+                rc4_keystream: Keystream::Rc4 {
+                    outgoing: rc4_outgoing,
+                    incoming: rc4_incoming,
+                },
+                substate: Packet4State::Vc,
+            };
+        }
+        // Else (called too many times): Error?  Do nothing?
+        Ok(())
+    }
+
+    /// Returns whether the handshake is complete (i.e., all of packet 4 has been received)
+    fn done(&self) -> bool {
+        matches!(self.state, HandshakeState::Done { .. })
+    }
+
+    /// Returns the final keystream and any initial encrypted data received after packet 4
+    fn into_keystream(self) -> (Keystream, Bytes) {
+        if let Handshaker {
+            state: HandshakeState::Done { keystream },
+            input_buffer,
+            ..
+        } = self
+        {
+            (keystream, input_buffer.freeze())
+        } else {
+            panic!("Handshaker::into_keystream() called before handshake completed");
+        }
+    }
+}
+
+enum HandshakeState {
+    Packet2 {
+        private_key: BigUint,
+    },
+    Packet4 {
+        rc4_keystream: Keystream,
+        substate: Packet4State,
+    },
+    Done {
+        keystream: Keystream,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum Packet4State {
+    /// Waiting for VC (initial 8 bytes of packet 4)
+    Vc,
+    /// Waiting for `crypto_select` (next 4 bytes of packet 4)
+    Select,
+    /// Waiting for `len(PadD)` (next 2 bytes of packet 4)
+    LenPadD { crypto_select: CryptoMethod },
+    /// Receiving contents of `PadD`
+    PadD {
+        crypto_select: CryptoMethod,
+        bytes_needed: usize,
+    },
+}
+
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub(crate) enum HandshakeError {
+    #[error("initial crypto handshake packet from server had invalid length: {0} bytes")]
+    Packet2Len(usize),
+    #[error("received invalid verification constant in crypto handshake")]
+    VcNotZero,
+    #[error("server selected {0} crypto methods instead of exactly 1")]
+    SelectNotSingle(u32),
+    #[error("server selected unknown crypto method {0:#x}")]
+    UnknownMethod(u32),
+    #[error("server selected crypto method {0:?} even though we didn't ask for it")]
+    UnexpectedSelection(CryptoMethod),
+}
+
+#[derive(Default)]
+enum Keystream {
+    #[default]
+    Plaintext,
+    Rc4 {
+        outgoing: Rc4<U20>,
+        incoming: Rc4<U20>,
+    },
+}
+
+impl Keystream {
+    /// Encode data before sending it to the server
+    fn encode(&mut self, bs: &mut [u8]) {
+        if let Keystream::Rc4 {
+            ref mut outgoing, ..
+        } = self
+        {
+            outgoing.apply_keystream(bs);
+        }
+    }
+
+    /// Decode incoming data received from the server
+    fn decode(&mut self, bs: &mut [u8]) {
+        if let Keystream::Rc4 {
+            ref mut incoming, ..
+        } = self
+        {
+            incoming.apply_keystream(bs);
+        }
+    }
+}
+
+pin_project_lite::pin_project! {
+    struct EncryptedStream {
+        #[pin]
+        inner: TcpStream,
+        keystream: Keystream,
+        // Bytes sent from the server after packet 4 that were received during the
+        // handshake and that now need to be decrypted & returned via the
+        // `AsyncRead` impl
+        read_buffer: Bytes,
+    }
+}
+
+impl EncryptedStream {
+    pub(super) async fn handshake<R: Rng>(
+        mut conn: TcpStream,
+        config: HandshakeBuilder<R>,
+    ) -> Result<Self, PeerError> {
+        let mut handshaker = config.build();
+        let mut timeout_time = None;
+        let mut n = 1;
+        while !handshaker.done() {
+            if let Some(mut outgoing) = handshaker.get_output() {
+                log::trace!(
+                    "Sending encryption handshake packet {n} to {}",
+                    handshaker.peer
+                );
+                n += 2;
+                conn.write_all_buf(&mut outgoing)
+                    .await
+                    .map_err(PeerError::Send)?;
+                conn.flush().await.map_err(PeerError::Send)?;
+            }
+            if let Some(timeout_len) = handshaker.get_timeout() {
+                timeout_time = Some(Instant::now() + timeout_len);
+            }
+            let mut buf = BytesMut::with_capacity(65535);
+            let fut = conn.read_buf(&mut buf);
+            let r = if let Some(deadline) = timeout_time {
+                timeout_at(deadline, fut).await.ok()
+            } else {
+                Some(fut.await)
+            };
+            match r {
+                Some(Ok(0)) => return Err(PeerError::Disconnect),
+                Some(Ok(_)) => handshaker.handle_input(buf.freeze())?,
+                Some(Err(e)) => return Err(PeerError::Recv(e)),
+                None => {
+                    log::trace!(
+                        "Finished receiving encryption handshake packet 2 from {}",
+                        handshaker.peer
+                    );
+                    handshaker.handle_timeout()?;
+                }
+            }
+        }
+        let (keystream, read_buffer) = handshaker.into_keystream();
+        Ok(EncryptedStream {
+            inner: conn,
+            keystream,
+            read_buffer,
+        })
+    }
+}
+
+impl AsyncRead for EncryptedStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = self.project();
+        let prelen = buf.filled().len();
+        let r = if !this.read_buffer.is_empty() {
+            let sz = buf.remaining().min(this.read_buffer.len());
+            let bs = this.read_buffer.split_to(sz);
+            buf.put_slice(bs.as_ref());
+            Ok(())
+        } else {
+            ready!(this.inner.poll_read(cx, buf))
+        };
+        if r.is_ok() && buf.filled().len() > prelen {
+            this.keystream.decode(&mut buf.filled_mut()[prelen..]);
+        }
+        r.into()
+    }
+}
+
+impl AsyncWrite for EncryptedStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        todo!()
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.project().inner.poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.project().inner.poll_shutdown(cx)
+    }
+}
+
+fn hash<S: AsRef<[u8]>>(bs: S) -> GenericArray<u8, U20> {
+    Sha1::digest(bs)
+}
+
+fn gen_private_key<R: Rng>(rng: &mut R) -> BigUint {
+    /*
+        // Post-<https://github.com/rust-num/num-bigint/pull/322>:
+        // Requires "rand" feature of num_bigint
+        use num_bigint::RandBigInt;
+        rng.random_biguint(160)
+    */
+    let bytes = rng.random_iter::<u8>().take(20).collect::<Vec<_>>();
+    BigUint::from_bytes_be(&bytes)
+}
+
+fn prime_modulus() -> BigUint {
+    BigUint::parse_bytes(
+        concat!(
+            "ffffffffffffffffc90fdaa22168c234c4c6628b80dc1cd129024e088a67cc74",
+            "020bbea63b139b22514a08798e3404ddef9519b3cd3a431b302b0a6df25f1437",
+            "4fe1356d6d51c245e485b576625e7ec6f44c42e9a63a36210000000000090563",
+        )
+        .as_bytes(),
+        16,
+    )
+    .expect("prime modulus string should be valid")
+}
+
+fn biguint2bytes(bi: &BigUint) -> Vec<u8> {
+    let mut bytes = bi.to_bytes_be();
+    if let Some(deficit) = MODULUS_BYTES.checked_sub(bytes.len()) {
+        let mut bytes2 = vec![0u8; deficit];
+        bytes2.append(&mut bytes);
+        bytes = bytes2;
+    }
+    debug_assert_eq!(
+        bytes.len(),
+        MODULUS_BYTES,
+        "encoded DH integer should be same size as modulus"
+    );
+    bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prime_modulus() {
+        // Test that it doesn't panic
+        let _ = prime_modulus();
+    }
+}

--- a/src/torrent.rs
+++ b/src/torrent.rs
@@ -113,7 +113,7 @@ impl TorrentInfoBuilder {
         if left > 0 {
             return Err(BuildError::NotFinished { left });
         }
-        let got_hash = Bytes::from(self.hasher.finalize().to_vec());
+        let got_hash = Bytes::from_iter(self.hasher.finalize());
         if got_hash != self.info_hash.as_bytes() {
             return Err(BuildError::Digest {
                 expected: self.info_hash,

--- a/src/tracker/http.rs
+++ b/src/tracker/http.rs
@@ -384,26 +384,31 @@ mod tests {
                             .parse::<SocketAddr>()
                             .unwrap(),
                         id: Some(PeerId::from(b"-TR3000-23xhfykztwo8")),
+                        requires_crypto: false,
                     },
                     Peer {
                         address: "[2001:41d0:e:907::1]:12179".parse::<SocketAddr>().unwrap(),
                         id: Some(PeerId::from(
                             b"-lt0D80-\xf8\x01\x92N+!{\x06\xcc\x15\xf0\xc4"
                         )),
+                        requires_crypto: false,
                     },
                     Peer {
                         address: "185.125.190.59:6892".parse::<SocketAddr>().unwrap(),
                         id: Some(PeerId::from(b"T03I--00N4b1YqQdAWh4")),
+                        requires_crypto: false,
                     },
                     Peer {
                         address: "[2403:5812:a03e::222]:51413".parse::<SocketAddr>().unwrap(),
                         id: Some(PeerId::from(b"-TR3000-83e2ltycmh6c")),
+                        requires_crypto: false,
                     },
                     Peer {
                         address: "[2003:f1:6f0f:dd00:c0ab:7cff:febd:274a]:51413"
                             .parse::<SocketAddr>()
                             .unwrap(),
                         id: Some(PeerId::from(b"-TR3000-9e0zt0knchh4")),
+                        requires_crypto: false,
                     },
                 ],
                 warning_message: None,

--- a/src/tracker/http.rs
+++ b/src/tracker/http.rs
@@ -73,6 +73,7 @@ impl HttpTrackerSession {
         announcement.event.add_query_param(&mut url);
         announcement.info_hash.add_query_param(&mut url);
         announcement.peer_id.add_query_param(&mut url);
+        announcement.crypto.add_query_param(&mut url);
         url.query_pairs_mut()
             .append_pair("port", &announcement.port.to_string())
             .append_pair("uploaded", &announcement.uploaded.to_string())
@@ -80,8 +81,7 @@ impl HttpTrackerSession {
             .append_pair("left", &announcement.left.to_string())
             .append_pair("numwant", &announcement.numwant.to_string())
             .append_pair("key", &announcement.key.to_string())
-            .append_pair("compact", "1")
-            .append_pair("supportcrypto", "1");
+            .append_pair("compact", "1");
         let buf = self
             .client
             .get(url)

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -149,6 +149,7 @@ impl TrackerSession {
             key: self.app.local.key,
             numwant: self.app.cfg.trackers.numwant.get(),
             port: self.app.local.port,
+            crypto: self.app.get_tracker_crypto(),
         })
         .await
     }
@@ -169,6 +170,7 @@ impl TrackerSession {
             key: self.app.local.key,
             numwant: self.app.cfg.trackers.numwant.get(),
             port: self.app.local.port,
+            crypto: self.app.get_tracker_crypto(),
         })
         .await
     }
@@ -259,6 +261,7 @@ struct Announcement {
     key: Key,
     numwant: u32,
     port: u16,
+    crypto: TrackerCrypto,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -272,4 +275,28 @@ struct AnnounceResponse {
     incomplete: Option<u32>,
     leechers: Option<u32>,
     seeders: Option<u32>,
+}
+
+/// Possible levels of encryption support to include in tracker announcements;
+/// only used by HTTP trackers
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) enum TrackerCrypto {
+    Required,
+    #[default]
+    Supported,
+    Nil,
+}
+
+impl TrackerCrypto {
+    fn add_query_param(&self, url: &mut Url) {
+        match self {
+            TrackerCrypto::Required => {
+                url.query_pairs_mut().append_pair("requirecrypto", "1");
+            }
+            TrackerCrypto::Supported => {
+                url.query_pairs_mut().append_pair("supportcrypto", "1");
+            }
+            TrackerCrypto::Nil => (),
+        }
+    }
 }

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -151,13 +151,8 @@ enum InnerTrackerSession {
 
 impl TrackerSession {
     fn get_tracker_crypto(&self) -> TrackerCrypto {
-        self.tracker_crypto.unwrap_or_else(|| {
-            self.app
-                .cfg
-                .peers
-                .encryption_preference
-                .get_tracker_crypto()
-        })
+        self.tracker_crypto
+            .unwrap_or_else(|| self.app.cfg.general.encrypt.get_tracker_crypto())
     }
 
     fn tracker_display(&self) -> String {

--- a/src/tracker/udp.rs
+++ b/src/tracker/udp.rs
@@ -460,7 +460,7 @@ pub(crate) enum UdpTrackerError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tracker::AnnounceEvent;
+    use crate::tracker::{AnnounceEvent, TrackerCrypto};
     use crate::types::{InfoHash, Key, PeerId};
 
     #[test]
@@ -500,6 +500,7 @@ mod tests {
                 uploaded: 0,
                 left: (1 << 63) - 1,
                 numwant: 80,
+                crypto: TrackerCrypto::default(),
             },
             urldata: String::new(),
         };
@@ -526,6 +527,7 @@ mod tests {
                 uploaded: 0,
                 left: (1 << 63) - 1,
                 numwant: 80,
+                crypto: TrackerCrypto::default(),
             },
             urldata: "/announce".into(),
         };

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,7 +15,7 @@ use url::Url;
 pub(crate) struct InfoHash([u8; InfoHash::LENGTH]);
 
 impl InfoHash {
-    const LENGTH: usize = 20;
+    pub(crate) const LENGTH: usize = 20;
 
     pub(crate) fn from_hex(s: &str) -> Result<InfoHash, InfoHashError> {
         HEXLOWER_PERMISSIVE


### PR DESCRIPTION
Closes #107.

To Do:

- [x] Implement `AsyncWrite` for `EncryptedConnection`
- [x] Implement creation of encrypted connections when connecting to a peer
- [x] Send `supportcrypto=1` to HTTP trackers and extract data from `crypto_flags` field
- [x] Write unit tests for `msepe.rs`
- [x] Store & report the `e` field in BEP 10 extended handshakes
- [x] Make `Peer.display_json()` emit a `requires_crypto: bool` field
- [x] Somehow handle deduplication of peers from different trackers when one tracker returns `crypto_flags` and another doesn't
- [x] Give `query-tracker` an option for whether to declare `supportcrypto` vs. `requirecrypto` vs. neither
- [x] Give `query-peer` one or more options for whether to use encryption (choices: yes, fallback, no)
- [x] Support the user configuring when encryption should be used
    - Choices:
        - `"always"` — always use encryption
            - This should cause HTTP tracker announcements to use `requirecrypto=1`
        - `"fallback"`(?) (`"try"`? `"encrypt-first"`? `"try-encrypt-first"`? `"try-first"`? `"encrypt-then-plain"`? `"prefer"`?) — try encryption first; if that fails, and if peer does not require encryption, try unencrypted
            - This is the default.
            - When falling back, the peer handshake timeout is reset.
        - `"if-required"` — use encryption iff peer requires encryption
        - `"never"` — don't use encryption; don't connect to peers that require it
            - This should cause HTTP tracker announcements to not use `supportcrypto=1`
- [x] Support the user configuring the packet 2 receipt duration
- [x] Rethink the name of the "fallback" choice for `peers.encryption-preference` (and also the `--try-encrypt` option to `query-peer`)
- [x] Test in action
- [x] Update README
- [x] Update CHANGELOG