### PR TITLE
Add configuration file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ v0.5.0 (in development)
 -----------------------
 - Fix "Saving torrent to file" message when torrent is actually being written
   to stdout
+- Added support for configuration files
 
 v0.4.0 (2025-05-17)
 -------------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "chrono",
  "clap",
  "data-encoding",
+ "directories",
  "fern",
  "futures-util",
  "log",
@@ -337,6 +338,7 @@ dependencies = [
  "rand",
  "reqwest",
  "rstest",
+ "serde",
  "sha1",
  "strum",
  "strum_macros",
@@ -344,6 +346,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "toml",
  "url",
 ]
 
@@ -361,6 +364,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -893,6 +917,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1076,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "patharg"
@@ -1231,6 +1271,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1543,6 +1594,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,6 +1893,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tower"
@@ -2311,6 +2412,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
  "chrono",
  "clap",
  "data-encoding",
- "directories",
+ "dirs",
  "fern",
  "futures-util",
  "log",
@@ -367,10 +367,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,15 +2190,15 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.1"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.1",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -2242,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
@@ -2260,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bytes = "1.6.0"
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std"] }
 clap = { version = "4.5.4", default-features = false, features = ["derive", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
 data-encoding = "2.6.0"
-directories = "6.0.0"
+dirs = "6.0.0"
 fern = "0.7.0"
 futures-util = { version = "0.3.30", default-features = false, features = ["sink"] }
 log = "0.4.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ bytes = "1.6.0"
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std"] }
 clap = { version = "4.5.4", default-features = false, features = ["derive", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
 data-encoding = "2.6.0"
+directories = "6.0.0"
 fern = "0.7.0"
 futures-util = { version = "0.3.30", default-features = false, features = ["sink"] }
 log = "0.4.21"
@@ -27,12 +28,14 @@ patharg = { version = "0.4.0", features = ["tokio"] }
 pin-project-lite = "0.2.14"
 rand = "0.9.0"
 reqwest = { version = "0.12.4", default-features = false, features = ["http2"] }
+serde = { version = "1.0.219", features = ["derive"] }
 sha1 = "0.10.6"
 strum = "0.27.0"
 strum_macros = "0.27.0"
 thiserror = "2.0.0"
 tokio = { version = "1.37.0", features = ["fs", "io-util", "macros", "sync", "rt", "rt-multi-thread", "time", "net"] }
 tokio-util = { version = "0.7.11", features = ["codec", "rt"] }
+toml = "0.8.22"
 url = "2.5.0"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -95,9 +95,15 @@ metadata from a single peer).
 Global Options
 --------------
 
+- `-c <file>`, `--config <file>` — Specify the configuration file to use.  See
+  "Configuration" below for the default config file location.
+
 - `-l <level>`, `--log-level <level>` — Set the log level to the given value.
   Possible values are "`OFF`", "`ERROR`", "`WARN`", "`INFO`", "`DEBUG`", and
   "`TRACE`" (all case-insensitive).  [default value: `INFO`]
+
+- `--no-config` — Use the default configuration settings and do not read from
+  any configuration files
 
 
 `demagnetize get`
@@ -181,3 +187,52 @@ information.
   replaced by the torrent's info hash in hexadecimal.  Specifying `-` will
   cause the torrent to be written to standard output.  [default:
   `{name}.torrent`]
+
+
+Configuration
+=============
+
+`demagnetize` can be configured via a [TOML](https://toml.io) file whose
+default location depends on your OS:
+
+- Linux — `~/.config/demagnetize/config.toml` or `$XDG_CONFIG_HOME/demagnetize/config.toml`
+- macOS — `~/Library/Application Support/demagnetize/config.toml`
+- Windows — `%USERPROFILE%\AppData\Local\demagnetize\config.toml`
+
+This file may contain the following tables & keys, all of which are optional:
+
+- `[general]` — settings that don't fit anywhere more specific
+    - `batch-jobs` (positive integer; default 50) — the maximum number of
+      magnet links that the `batch` command will operate on at once
+
+- `[peers]` — settings for interacting with peers
+    - `handshake-timeout` (nonnegative integer; default 60) — When connecting
+      to a peer, if the TCP connection and BitTorrent handshake are not both
+      completed within this many seconds, the peer is abandoned.
+    - `jobs-per-magnet` (positive integer; default 30) — the maximum number of
+      peers per magnet link that `demagnetize` will communicate with at once
+
+- `[trackers]` — settings for interacting with trackers
+    - `announce-timeout` (nonnegative integer; default 30) — When sending a
+      "started" announcement to a tracker & receiving a list of peers in
+      response, if the task does not complete within this many seconds, the
+      tracker is abandoned.
+    - `jobs-per-magnet` (positive integer; default 30) — the maximum number of
+      trackers per magnet link that `demagnetize` will communicate with at once
+    - `local-port` — the port number that `demagnetize` will tell trackers it's
+      receiving peer connections on
+        - This can be either a port number or a string containing two port
+          numbers separated by a hyphen (in which case a port in the given
+          inclusive range will be chosen at random).  The default is
+          `"1025-65535"`, which selects any nonprivileged port at random.
+        - Note that `demagnetize` does not actually use the port in question,
+          and no attempt is made to ensure the port is not already in use.  On
+          the other hand, `demagnetize` sends a "stop" announcement to each
+          tracker immediately after receiving the list of peers, so hopefully
+          no other peers will see the port number.
+    - `numwant` (positive integer; default 50) — the number of peers to request
+      from each tracker
+    - `shutdown-timeout` (nonnegative integer; default 3) — At the end of
+      program operation, wait this many seconds for any outstanding "stopped"
+      announcements to complete; any tasks still running after the timeout are
+      forcibly cancelled.

--- a/THIRDPARTY.toml
+++ b/THIRDPARTY.toml
@@ -6909,6 +6909,424 @@ limitations under the License.
 """
 
 [[third_party_libraries]]
+package_name = "directories"
+package_version = "6.0.0"
+repository = "https://github.com/soc/directories-rs"
+license = "MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Copyright (c) 2018 directories-rs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \"Software\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   \"License\" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   \"Licensor\" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   \"Legal Entity\" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   \"control\" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   \"You\" (or \"Your\") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   \"Source\" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   \"Object\" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   \"Work\" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   \"Derivative Works\" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   \"Contribution\" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, \"submitted\"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as \"Not a Contribution.\"
+
+   \"Contributor\" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a \"NOTICE\" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+"""
+
+[[third_party_libraries]]
+package_name = "dirs-sys"
+package_version = "0.5.0"
+repository = "https://github.com/dirs-dev/dirs-sys-rs"
+license = "MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Copyright (c) 2018-2019 dirs-rs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \"Software\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   \"License\" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   \"Licensor\" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   \"Legal Entity\" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   \"control\" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   \"You\" (or \"Your\") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   \"Source\" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   \"Object\" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   \"Work\" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   \"Derivative Works\" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   \"Contribution\" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, \"submitted\"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as \"Not a Contribution.\"
+
+   \"Contributor\" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a \"NOTICE\" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+"""
+
+[[third_party_libraries]]
 package_name = "displaydoc"
 package_version = "0.2.5"
 repository = "https://github.com/yaahc/displaydoc"
@@ -16168,6 +16586,38 @@ END OF TERMS AND CONDITIONS
 """
 
 [[third_party_libraries]]
+package_name = "libredox"
+package_version = "0.1.3"
+repository = "https://gitlab.redox-os.org/redox-os/libredox.git"
+license = "MIT"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+MIT License
+
+Copyright (c) 2023 4lDO2
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \"Software\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+[[third_party_libraries]]
 package_name = "linux-raw-sys"
 package_version = "0.9.4"
 repository = "https://github.com/sunfishcode/linux-raw-sys"
@@ -19434,6 +19884,390 @@ DEALINGS IN THE SOFTWARE.
 """
 
 [[third_party_libraries]]
+package_name = "option-ext"
+package_version = "0.2.0"
+repository = "https://github.com/soc/option-ext.git"
+license = "MPL-2.0"
+
+[[third_party_libraries.licenses]]
+license = "MPL-2.0"
+text = """
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. \"Contributor\"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. \"Contributor Version\"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. \"Contribution\"
+    means Covered Software of a particular Contributor.
+
+1.4. \"Covered Software\"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. \"Incompatible With Secondary Licenses\"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. \"Executable Form\"
+    means any form of the work other than Source Code Form.
+
+1.7. \"Larger Work\"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. \"License\"
+    means this document.
+
+1.9. \"Licensable\"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. \"Modifications\"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. \"Patent Claims\" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. \"Secondary License\"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. \"Source Code Form\"
+    means the form of the work preferred for making modifications.
+
+1.14. \"You\" (or \"Your\")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, \"You\" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, \"control\" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an \"as is\"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - \"Incompatible With Secondary Licenses\" Notice
+---------------------------------------------------------
+
+  This Source Code Form is \"Incompatible With Secondary Licenses\", as
+  defined by the Mozilla Public License, v. 2.0.
+"""
+
+[[third_party_libraries]]
 package_name = "patharg"
 package_version = "0.4.0"
 repository = "https://github.com/jwodder/patharg"
@@ -22247,6 +23081,39 @@ APPENDIX: How to apply the Apache License to your work.
    file or class name and description of purpose be included on the
    same \"printed page\" as the copyright notice for easier
    identification within third-party archives.
+"""
+
+[[third_party_libraries]]
+package_name = "redox_users"
+package_version = "0.5.0"
+repository = "https://gitlab.redox-os.org/redox-os/users"
+license = "MIT"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+The MIT License (MIT)
+
+Copyright (c) 2017 Jose Narvaez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \"Software\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 """
 
 [[third_party_libraries]]
@@ -26303,6 +27170,243 @@ END OF TERMS AND CONDITIONS
 """
 
 [[third_party_libraries]]
+package_name = "serde_spanned"
+package_version = "0.6.8"
+repository = "https://github.com/toml-rs/toml"
+license = "MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Copyright (c) Individual contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \"Software\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      \"License\" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      \"Licensor\" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      \"Legal Entity\" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      \"control\" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      \"You\" (or \"Your\") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      \"Source\" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      \"Object\" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      \"Work\" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      \"Derivative Works\" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      \"Contribution\" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, \"submitted\"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as \"Not a Contribution.\"
+
+      \"Contributor\" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a \"NOTICE\" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an \"AS IS\" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets \"{}\"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same \"printed page\" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the \"License\");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+"""
+
+[[third_party_libraries]]
 package_name = "serde_urlencoded"
 package_version = "0.7.1"
 repository = "https://github.com/nox/serde_urlencoded"
@@ -30215,6 +31319,954 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+"""
+
+[[third_party_libraries]]
+package_name = "toml"
+package_version = "0.8.22"
+repository = "https://github.com/toml-rs/toml"
+license = "MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Copyright (c) Individual contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \"Software\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      \"License\" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      \"Licensor\" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      \"Legal Entity\" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      \"control\" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      \"You\" (or \"Your\") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      \"Source\" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      \"Object\" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      \"Work\" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      \"Derivative Works\" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      \"Contribution\" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, \"submitted\"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as \"Not a Contribution.\"
+
+      \"Contributor\" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a \"NOTICE\" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an \"AS IS\" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets \"{}\"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same \"printed page\" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the \"License\");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+"""
+
+[[third_party_libraries]]
+package_name = "toml_datetime"
+package_version = "0.6.9"
+repository = "https://github.com/toml-rs/toml"
+license = "MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Copyright (c) Individual contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \"Software\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      \"License\" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      \"Licensor\" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      \"Legal Entity\" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      \"control\" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      \"You\" (or \"Your\") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      \"Source\" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      \"Object\" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      \"Work\" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      \"Derivative Works\" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      \"Contribution\" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, \"submitted\"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as \"Not a Contribution.\"
+
+      \"Contributor\" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a \"NOTICE\" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an \"AS IS\" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets \"{}\"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same \"printed page\" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the \"License\");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+"""
+
+[[third_party_libraries]]
+package_name = "toml_edit"
+package_version = "0.22.26"
+repository = "https://github.com/toml-rs/toml"
+license = "MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Copyright (c) Individual contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \"Software\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      \"License\" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      \"Licensor\" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      \"Legal Entity\" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      \"control\" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      \"You\" (or \"Your\") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      \"Source\" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      \"Object\" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      \"Work\" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      \"Derivative Works\" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      \"Contribution\" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, \"submitted\"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as \"Not a Contribution.\"
+
+      \"Contributor\" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a \"NOTICE\" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an \"AS IS\" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets \"{}\"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same \"printed page\" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the \"License\");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+"""
+
+[[third_party_libraries]]
+package_name = "toml_write"
+package_version = "0.1.1"
+repository = "https://github.com/toml-rs/toml"
+license = "MIT OR Apache-2.0"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Copyright (c) Individual contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \"Software\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+[[third_party_libraries.licenses]]
+license = "Apache-2.0"
+text = """
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      \"License\" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      \"Licensor\" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      \"Legal Entity\" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      \"control\" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      \"You\" (or \"Your\") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      \"Source\" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      \"Object\" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      \"Work\" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      \"Derivative Works\" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      \"Contribution\" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, \"submitted\"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as \"Not a Contribution.\"
+
+      \"Contributor\" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a \"NOTICE\" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an \"AS IS\" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets \"{}\"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same \"printed page\" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the \"License\");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an \"AS IS\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
 """
 
 [[third_party_libraries]]
@@ -34932,7 +36984,7 @@ insights.
 
 [[third_party_libraries]]
 package_name = "windows-core"
-package_version = "0.61.1"
+package_version = "0.61.0"
 repository = "https://github.com/microsoft/windows-rs"
 license = "MIT OR Apache-2.0"
 
@@ -36122,7 +38174,7 @@ text = """
 
 [[third_party_libraries]]
 package_name = "windows-result"
-package_version = "0.3.3"
+package_version = "0.3.4"
 repository = "https://github.com/microsoft/windows-rs"
 license = "MIT OR Apache-2.0"
 
@@ -36598,7 +38650,7 @@ text = """
 
 [[third_party_libraries]]
 package_name = "windows-strings"
-package_version = "0.4.1"
+package_version = "0.4.2"
 repository = "https://github.com/microsoft/windows-rs"
 license = "MIT OR Apache-2.0"
 
@@ -41592,6 +43644,35 @@ text = """
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+"""
+
+[[third_party_libraries]]
+package_name = "winnow"
+package_version = "0.7.10"
+repository = "https://github.com/winnow-rs/winnow"
+license = "MIT"
+
+[[third_party_libraries.licenses]]
+license = "MIT"
+text = """
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+\"Software\"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 [[third_party_libraries]]

--- a/THIRDPARTY.toml
+++ b/THIRDPARTY.toml
@@ -6909,15 +6909,15 @@ limitations under the License.
 """
 
 [[third_party_libraries]]
-package_name = "directories"
+package_name = "dirs"
 package_version = "6.0.0"
-repository = "https://github.com/soc/directories-rs"
+repository = "https://github.com/soc/dirs-rs"
 license = "MIT OR Apache-2.0"
 
 [[third_party_libraries.licenses]]
 license = "MIT"
 text = """
-Copyright (c) 2018 directories-rs contributors
+Copyright (c) 2018-2019 dirs-rs contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the \"Software\"), to deal

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,38 @@
+use crate::config::Config;
+use crate::consts::PEER_ID_PREFIX;
+use crate::types::{Key, PeerId};
+use rand::Rng;
+use std::fmt;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct App {
+    pub(crate) cfg: Config,
+    pub(crate) local: LocalPeer,
+}
+
+impl App {
+    pub(crate) fn new<R: Rng>(cfg: Config, mut rng: R) -> App {
+        let id = PeerId::generate(PEER_ID_PREFIX, &mut rng);
+        let key = rng.random::<Key>();
+        let port = cfg.trackers.local_port.generate(&mut rng);
+        let local = LocalPeer { id, key, port };
+        App { cfg, local }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LocalPeer {
+    pub(crate) id: PeerId,
+    pub(crate) key: Key,
+    pub(crate) port: u16,
+}
+
+impl fmt::Display for LocalPeer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "id = {}, key = {}, port = {}",
+            self.id, self.key, self.port
+        )
+    }
+}

--- a/src/asyncutil/shutdown_group.rs
+++ b/src/asyncutil/shutdown_group.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use tokio::time::timeout;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
-// TODO: Should there be a limit on the number of tasks running at once?
 #[derive(Debug, Default)]
 pub(crate) struct ShutdownGroup {
     tracker: TaskTracker,

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,13 +21,13 @@ pub(crate) struct Config {
 }
 
 impl Config {
-    pub(crate) fn default_path() -> PathBuf {
-        let Some(projdirs) = ProjectDirs::from("", "jwodder", "demagnetize") else {
-            // Return something almost reasonable if $HOME can't be determined
-            // TODO: Error instead?
-            return ".config/demagnetize/config.toml".into();
-        };
-        projdirs.config_local_dir().join("config.toml")
+    // Returns `None` if $HOME cannot be determined
+    pub(crate) fn default_path() -> Option<PathBuf> {
+        Some(
+            ProjectDirs::from("", "jwodder", "demagnetize")?
+                .config_local_dir()
+                .join("config.toml"),
+        )
     }
 
     pub(crate) fn load<P: AsRef<Path>>(path: P) -> Result<Config, ConfigError> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,7 @@ impl Config {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct GeneralConfig {
+    /// Maximum number of magnet links to operate on at once in batch mode
     #[serde(default = "default_batch_jobs")]
     pub(crate) batch_jobs: NonZeroUsize,
 }
@@ -57,18 +58,22 @@ pub(crate) struct TrackersConfig {
     #[serde(default)]
     pub(crate) local_port: LocalPort,
 
+    /// Number of peers to request per tracker
     #[serde(default = "default_numwant")]
     pub(crate) numwant: NonZeroU32,
 
+    /// Maximum number of trackers per magnet link to communicate with at once
     #[serde(default = "default_tracker_jobs_per_magnet")]
     pub(crate) jobs_per_magnet: NonZeroUsize,
 
+    /// Overall timeout for interacting with a tracker
     #[serde(
         default = "default_announce_timeout",
         deserialize_with = "deserialize_seconds"
     )]
     pub(crate) announce_timeout: Duration,
 
+    /// Timeout for sending & receiving a "stopped" announcement to a tracker
     #[serde(
         default = "default_shutdown_timeout",
         deserialize_with = "deserialize_seconds"
@@ -91,9 +96,12 @@ impl Default for TrackersConfig {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct PeersConfig {
+    /// Maximum number of peers per magnet link to interact with at once
     #[serde(default = "default_peer_jobs_per_magnet")]
     pub(crate) jobs_per_magnet: NonZeroUsize,
 
+    /// Timeout for connecting to a peer and performing the BitTorrent
+    /// handshake and extended handshake
     #[serde(
         default = "default_handshake_timeout",
         deserialize_with = "deserialize_seconds"

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,7 +40,7 @@ impl Config {
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct GeneralConfig {
     #[serde(default = "default_batch_jobs")]
-    batch_jobs: NonZeroUsize,
+    pub(crate) batch_jobs: NonZeroUsize,
 }
 
 impl Default for GeneralConfig {
@@ -55,25 +55,25 @@ impl Default for GeneralConfig {
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct TrackersConfig {
     #[serde(default)]
-    local_port: LocalPort,
+    pub(crate) local_port: LocalPort,
 
     #[serde(default = "default_numwant")]
-    numwant: NonZeroU32,
+    pub(crate) numwant: NonZeroU32,
 
     #[serde(default = "default_tracker_jobs_per_magnet")]
-    jobs_per_magnet: NonZeroUsize,
+    pub(crate) jobs_per_magnet: NonZeroUsize,
 
     #[serde(
         default = "default_announce_timeout",
         deserialize_with = "deserialize_seconds"
     )]
-    announce_timeout: Duration,
+    pub(crate) announce_timeout: Duration,
 
     #[serde(
         default = "default_shutdown_timeout",
         deserialize_with = "deserialize_seconds"
     )]
-    shutdown_timeout: Duration,
+    pub(crate) shutdown_timeout: Duration,
 }
 
 impl Default for TrackersConfig {
@@ -92,13 +92,13 @@ impl Default for TrackersConfig {
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct PeersConfig {
     #[serde(default = "default_peer_jobs_per_magnet")]
-    jobs_per_magnet: NonZeroUsize,
+    pub(crate) jobs_per_magnet: NonZeroUsize,
 
     #[serde(
         default = "default_handshake_timeout",
         deserialize_with = "deserialize_seconds"
     )]
-    handshake_timeout: Duration,
+    pub(crate) handshake_timeout: Duration,
 }
 
 impl Default for PeersConfig {
@@ -229,9 +229,9 @@ impl<'de> Deserialize<'de> for LocalPort {
 
 #[derive(Debug, Error)]
 pub(crate) enum ConfigError {
-    #[error("failed to read configuration file")]
+    #[error("error reading configuration file")]
     Read(#[from] std::io::Error),
-    #[error("failed to parse configuration file")]
+    #[error("error parsing configuration file")]
     Parse(#[from] toml::de::Error),
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ impl Config {
     pub(crate) fn default_path() -> PathBuf {
         let Some(projdirs) = ProjectDirs::from("", "jwodder", "demagnetize") else {
             // Return something almost reasonable if $HOME can't be determined
+            // TODO: Error instead?
             return ".config/demagnetize/config.toml".into();
         };
         projdirs.config_local_dir().join("config.toml")
@@ -133,6 +134,42 @@ impl Default for LocalPort {
     }
 }
 
+macro_rules! try_visit_int {
+    ($($t:ty, $visit:ident),* $(,)?) => {
+        $(
+            fn $visit<E>(self, p: $t) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                u16::try_from(p).map(LocalPort::Constant).map_err(|_| {
+                    E::invalid_value(
+                        Unexpected::Signed(p.into()),
+                        &"port number out of range; must be from 0 to 65535",
+                    )
+                })
+            }
+        )*
+    }
+}
+
+macro_rules! try_visit_uint {
+    ($($t:ty, $visit:ident),* $(,)?) => {
+        $(
+            fn $visit<E>(self, p: $t) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                u16::try_from(p).map(LocalPort::Constant).map_err(|_| {
+                    E::invalid_value(
+                        Unexpected::Unsigned(p.into()),
+                        &"port number out of range; must be from 0 to 65535",
+                    )
+                })
+            }
+        )*
+    }
+}
+
 impl<'de> Deserialize<'de> for LocalPort {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct Visitor;
@@ -146,12 +183,22 @@ impl<'de> Deserialize<'de> for LocalPort {
                 )
             }
 
+            fn visit_u8<E>(self, p: u8) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(LocalPort::Constant(u16::from(p)))
+            }
+
             fn visit_u16<E>(self, p: u16) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
                 Ok(LocalPort::Constant(p))
             }
+
+            try_visit_int!(i8, visit_i8, i16, visit_i16, i32, visit_i32, i64, visit_i64);
+            try_visit_uint!(u32, visit_u32, u64, visit_u64);
 
             fn visit_str<E>(self, input: &str) -> Result<Self::Value, E>
             where
@@ -221,4 +268,203 @@ where
     D: Deserializer<'de>,
 {
     u64::deserialize(deserializer).map(Duration::from_secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn default_config() {
+        let cfg = Config::default();
+        assert_eq!(
+            cfg,
+            Config {
+                general: GeneralConfig {
+                    batch_jobs: NonZeroUsize::new(50).unwrap(),
+                },
+                trackers: TrackersConfig {
+                    local_port: LocalPort::default(),
+                    numwant: NonZeroU32::new(50).unwrap(),
+                    jobs_per_magnet: NonZeroUsize::new(30).unwrap(),
+                    announce_timeout: Duration::from_secs(30),
+                    shutdown_timeout: Duration::from_secs(3),
+                },
+                peers: PeersConfig {
+                    jobs_per_magnet: NonZeroUsize::new(30).unwrap(),
+                    handshake_timeout: Duration::from_secs(60),
+                }
+            }
+        );
+    }
+
+    fn load_config(cfg: &str) -> Result<Config, ConfigError> {
+        let mut tmpfile = NamedTempFile::new().unwrap();
+        tmpfile.write_all(cfg.as_bytes()).unwrap();
+        tmpfile.flush().unwrap();
+        Config::load(tmpfile.path())
+    }
+
+    #[test]
+    fn empty_config() {
+        let cfg = load_config("").unwrap();
+        assert_eq!(cfg, Config::default());
+    }
+
+    #[test]
+    fn int_local_port() {
+        let cfg = load_config("[trackers]\nlocal-port = 60069\n").unwrap();
+        assert_eq!(
+            cfg,
+            Config {
+                trackers: TrackersConfig {
+                    local_port: LocalPort::Constant(60069),
+                    ..TrackersConfig::default()
+                },
+                ..Config::default()
+            }
+        );
+    }
+
+    #[test]
+    fn int_str_local_port() {
+        let cfg = load_config("[trackers]\nlocal-port = \"60069\"\n").unwrap();
+        assert_eq!(
+            cfg,
+            Config {
+                trackers: TrackersConfig {
+                    local_port: LocalPort::Constant(60069),
+                    ..TrackersConfig::default()
+                },
+                ..Config::default()
+            }
+        );
+    }
+
+    #[test]
+    fn local_port_range() {
+        let cfg = load_config("[trackers]\nlocal-port = \"3000-4000\"\n").unwrap();
+        assert_eq!(
+            cfg,
+            Config {
+                trackers: TrackersConfig {
+                    local_port: LocalPort::Range {
+                        low: 3000,
+                        high: 4000
+                    },
+                    ..TrackersConfig::default()
+                },
+                ..Config::default()
+            }
+        );
+    }
+
+    #[test]
+    fn local_port_spaced_range() {
+        let cfg = load_config("[trackers]\nlocal-port = \"3000 - 4000\"\n").unwrap();
+        assert_eq!(
+            cfg,
+            Config {
+                trackers: TrackersConfig {
+                    local_port: LocalPort::Range {
+                        low: 3000,
+                        high: 4000
+                    },
+                    ..TrackersConfig::default()
+                },
+                ..Config::default()
+            }
+        );
+    }
+
+    #[test]
+    fn local_port_eq_range() {
+        let cfg = load_config("[trackers]\nlocal-port = \"3000-3000\"\n").unwrap();
+        assert_eq!(
+            cfg,
+            Config {
+                trackers: TrackersConfig {
+                    local_port: LocalPort::Range {
+                        low: 3000,
+                        high: 3000
+                    },
+                    ..TrackersConfig::default()
+                },
+                ..Config::default()
+            }
+        );
+    }
+
+    #[test]
+    fn descending_local_port_range() {
+        assert!(load_config("[trackers]\nlocal-port = \"4000-3000\"\n").is_err());
+    }
+
+    #[test]
+    fn zero_duration() {
+        let cfg = load_config("[trackers]\nshutdown-timeout = 0\n").unwrap();
+        assert_eq!(
+            cfg,
+            Config {
+                trackers: TrackersConfig {
+                    shutdown_timeout: Duration::from_secs(0),
+                    ..TrackersConfig::default()
+                },
+                ..Config::default()
+            }
+        );
+    }
+
+    #[test]
+    fn full_config() {
+        let cfg = load_config(concat!(
+            "[general]\n",
+            "batch-jobs = 100\n",
+            "\n",
+            "[trackers]\n",
+            "local-port = \"10000-65535\"\n",
+            "numwant = 75\n",
+            "jobs-per-magnet = 42\n",
+            "announce-timeout = 45\n",
+            "shutdown-timeout = 5\n",
+            "\n",
+            "[peers]\n",
+            "jobs-per-magnet = 23\n",
+            "handshake-timeout = 120\n",
+        ))
+        .unwrap();
+        assert_eq!(
+            cfg,
+            Config {
+                general: GeneralConfig {
+                    batch_jobs: NonZeroUsize::new(100).unwrap(),
+                },
+                trackers: TrackersConfig {
+                    local_port: LocalPort::Range {
+                        low: 10000,
+                        high: 65535
+                    },
+                    numwant: NonZeroU32::new(75).unwrap(),
+                    jobs_per_magnet: NonZeroUsize::new(42).unwrap(),
+                    announce_timeout: Duration::from_secs(45),
+                    shutdown_timeout: Duration::from_secs(5),
+                },
+                peers: PeersConfig {
+                    jobs_per_magnet: NonZeroUsize::new(23).unwrap(),
+                    handshake_timeout: Duration::from_secs(120),
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn generate_local_port_single_range() {
+        let lp = LocalPort::Range {
+            low: 1025,
+            high: 1025,
+        };
+        assert_eq!(lp.generate(rand::rng()), 1025);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,224 @@
+use directories::ProjectDirs;
+use rand::Rng;
+use serde::{
+    de::{Deserializer, Unexpected},
+    Deserialize,
+};
+use std::fmt;
+use std::num::{NonZeroU32, NonZeroUsize};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use thiserror::Error;
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+pub(crate) struct Config {
+    #[serde(default)]
+    pub(crate) general: GeneralConfig,
+    #[serde(default)]
+    pub(crate) trackers: TrackersConfig,
+    #[serde(default)]
+    pub(crate) peers: PeersConfig,
+}
+
+impl Config {
+    pub(crate) fn default_path() -> PathBuf {
+        let Some(projdirs) = ProjectDirs::from("", "jwodder", "demagnetize") else {
+            // Return something almost reasonable if $HOME can't be determined
+            return ".config/demagnetize/config.toml".into();
+        };
+        projdirs.config_local_dir().join("config.toml")
+    }
+
+    pub(crate) fn load<P: AsRef<Path>>(path: P) -> Result<Config, ConfigError> {
+        let content = std::fs::read_to_string(path)?;
+        toml::from_str(&content).map_err(Into::into)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct GeneralConfig {
+    #[serde(default = "default_batch_jobs")]
+    batch_jobs: NonZeroUsize,
+}
+
+impl Default for GeneralConfig {
+    fn default() -> GeneralConfig {
+        GeneralConfig {
+            batch_jobs: default_batch_jobs(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct TrackersConfig {
+    #[serde(default)]
+    local_port: LocalPort,
+
+    #[serde(default = "default_numwant")]
+    numwant: NonZeroU32,
+
+    #[serde(default = "default_tracker_jobs_per_magnet")]
+    jobs_per_magnet: NonZeroUsize,
+
+    #[serde(
+        default = "default_announce_timeout",
+        deserialize_with = "deserialize_seconds"
+    )]
+    announce_timeout: Duration,
+
+    #[serde(
+        default = "default_shutdown_timeout",
+        deserialize_with = "deserialize_seconds"
+    )]
+    shutdown_timeout: Duration,
+}
+
+impl Default for TrackersConfig {
+    fn default() -> TrackersConfig {
+        TrackersConfig {
+            local_port: LocalPort::default(),
+            numwant: default_numwant(),
+            jobs_per_magnet: default_tracker_jobs_per_magnet(),
+            announce_timeout: default_announce_timeout(),
+            shutdown_timeout: default_shutdown_timeout(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct PeersConfig {
+    #[serde(default = "default_peer_jobs_per_magnet")]
+    jobs_per_magnet: NonZeroUsize,
+
+    #[serde(
+        default = "default_handshake_timeout",
+        deserialize_with = "deserialize_seconds"
+    )]
+    handshake_timeout: Duration,
+}
+
+impl Default for PeersConfig {
+    fn default() -> PeersConfig {
+        PeersConfig {
+            jobs_per_magnet: default_peer_jobs_per_magnet(),
+            handshake_timeout: default_handshake_timeout(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LocalPort {
+    Constant(u16),
+    Range { low: u16, high: u16 },
+}
+
+impl LocalPort {
+    pub(crate) fn generate<R: Rng>(&self, mut rng: R) -> u16 {
+        match *self {
+            LocalPort::Constant(p) => p,
+            LocalPort::Range { low, high } => rng.random_range(low..=high),
+        }
+    }
+}
+
+impl Default for LocalPort {
+    fn default() -> LocalPort {
+        LocalPort::Range {
+            low: 1025,
+            high: 65535,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for LocalPort {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Visitor;
+
+        impl serde::de::Visitor<'_> for Visitor {
+            type Value = LocalPort;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(
+                    "either a single port number or two ascending port numbers separated by a hyphen",
+                )
+            }
+
+            fn visit_u16<E>(self, p: u16) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(LocalPort::Constant(p))
+            }
+
+            fn visit_str<E>(self, input: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if input.chars().all(|c| c.is_ascii_digit()) {
+                    let Ok(p) = input.parse::<u16>() else {
+                        return Err(E::invalid_value(Unexpected::Str(input), &self));
+                    };
+                    Ok(LocalPort::Constant(p))
+                } else {
+                    let Some((pre, post)) = input.split_once('-') else {
+                        return Err(E::invalid_value(Unexpected::Str(input), &self));
+                    };
+                    let low = pre.trim().parse::<u16>().ok();
+                    let high = post.trim().parse::<u16>().ok();
+                    let Some((low, high)) = low.zip(high).filter(|(l, h)| l <= h) else {
+                        return Err(E::invalid_value(Unexpected::Str(input), &self));
+                    };
+                    Ok(LocalPort::Range { low, high })
+                }
+            }
+        }
+
+        deserializer.deserialize_str(Visitor)
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ConfigError {
+    #[error("failed to read configuration file")]
+    Read(#[from] std::io::Error),
+    #[error("failed to parse configuration file")]
+    Parse(#[from] toml::de::Error),
+}
+
+fn default_batch_jobs() -> NonZeroUsize {
+    NonZeroUsize::new(50).expect("default general.batch-jobs should be nonzero")
+}
+
+fn default_numwant() -> NonZeroU32 {
+    NonZeroU32::new(50).expect("default trackers.numwant should be nonzero")
+}
+
+fn default_tracker_jobs_per_magnet() -> NonZeroUsize {
+    NonZeroUsize::new(30).expect("default trackers.jobs-per-magnet should be nonzero")
+}
+
+fn default_announce_timeout() -> Duration {
+    Duration::from_secs(30)
+}
+
+fn default_shutdown_timeout() -> Duration {
+    Duration::from_secs(3)
+}
+
+fn default_peer_jobs_per_magnet() -> NonZeroUsize {
+    NonZeroUsize::new(30).expect("default peers.jobs-per-magnet should be nonzero")
+}
+
+fn default_handshake_timeout() -> Duration {
+    Duration::from_secs(60)
+}
+
+fn deserialize_seconds<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    u64::deserialize(deserializer).map(Duration::from_secs)
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use directories::ProjectDirs;
 use rand::Rng;
 use serde::{
     de::{Deserializer, Unexpected},
@@ -24,8 +23,8 @@ impl Config {
     // Returns `None` if $HOME cannot be determined
     pub(crate) fn default_path() -> Option<PathBuf> {
         Some(
-            ProjectDirs::from("", "jwodder", "demagnetize")?
-                .config_local_dir()
+            dirs::config_local_dir()?
+                .join("demagnetize")
                 .join("config.toml"),
         )
     }

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,14 +1,4 @@
 use crate::peer::extensions::Extension;
-use std::time::Duration;
-
-/// Number of peers to request per tracker
-pub(crate) const NUMWANT: u32 = 50;
-
-/// Overall timeout for interacting with a tracker
-pub(crate) const TRACKER_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// Timeout for sending & receiving a "stopped" announcement to a tracker
-pub(crate) const TRACKER_STOP_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// "left" value to use when announcing to a tracker for a torrent we have only
 /// the magnet link of
@@ -24,10 +14,6 @@ pub(crate) const UDP_PACKET_LEN: usize = 65535;
 /// Maximum metadata size to accept
 pub(crate) const MAX_INFO_LENGTH: usize = 20 << 20; // 20 MiB
 
-/// Timeout for connecting to a peer and performing the BitTorrent handshake
-/// and extended handshake
-pub(crate) const PEER_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(60);
-
 /// BitTorrent protocol extensions supported by demagnetize
 pub(crate) const SUPPORTED_EXTENSIONS: [Extension; 2] = [Extension::Bep10, Extension::Fast];
 
@@ -40,12 +26,3 @@ pub(crate) static CLIENT: &str = concat!(env!("CARGO_PKG_NAME"), " ", env!("CARG
 
 /// Maximum length of a message to accept from a peer
 pub(crate) const MAX_PEER_MSG_LEN: usize = 65535;
-
-/// Maximum number of trackers per magnet link to communicate with at once
-pub(crate) const TRACKERS_PER_MAGNET_LIMIT: usize = 30;
-
-/// Maximum number of peers per magnet link to interact with at once
-pub(crate) const PEERS_PER_MAGNET_LIMIT: usize = 30;
-
-/// Maximum number of magnet links to operate on at once in batch mode
-pub(crate) const MAGNET_LIMIT: usize = 50;

--- a/src/magnet.rs
+++ b/src/magnet.rs
@@ -1,8 +1,9 @@
+use crate::app::App;
 use crate::asyncutil::{BufferedTasks, ShutdownGroup, UniqueExt};
 use crate::consts::{PEERS_PER_MAGNET_LIMIT, TRACKERS_PER_MAGNET_LIMIT};
 use crate::torrent::{PathTemplate, TorrentFile};
 use crate::tracker::{Tracker, TrackerUrlError};
-use crate::types::{InfoHash, InfoHashError, LocalPeer};
+use crate::types::{InfoHash, InfoHashError};
 use crate::util::ErrorChain;
 use futures_util::stream::{iter, StreamExt};
 use patharg::InputArg;
@@ -35,7 +36,7 @@ impl Magnet {
 
     pub(crate) async fn get_torrent_file(
         &self,
-        local: LocalPeer,
+        app: Arc<App>,
         shutdown_group: Arc<ShutdownGroup>,
     ) -> Result<TorrentFile, GetInfoError> {
         log::info!("Fetching metadata info for {self}");
@@ -44,10 +45,11 @@ impl Magnet {
             TRACKERS_PER_MAGNET_LIMIT,
             self.trackers().iter().map(|tracker| {
                 let tracker = Arc::clone(tracker);
+                let app = Arc::clone(&app);
                 let group = Arc::clone(&shutdown_group);
                 let display = self.to_string();
                 async move {
-                    match tracker.get_peers(info_hash, local, group).await {
+                    match tracker.get_peers(info_hash, app, group).await {
                         Ok(peers) => iter(peers),
                         Err(e) => {
                             log::warn!(
@@ -69,9 +71,10 @@ impl Magnet {
             let peer_tasks = BufferedTasks::from_stream(
                 PEERS_PER_MAGNET_LIMIT,
                 peer_stream.map(|peer| {
+                    let app = Arc::clone(&app);
                     let sender = sender.clone();
                     async move {
-                        let r = peer.info_getter(info_hash, local).run().await;
+                        let r = peer.info_getter(info_hash, app).run().await;
                         let _ = sender.send((peer, r)).await;
                     }
                 }),
@@ -104,10 +107,10 @@ impl Magnet {
     pub(crate) async fn download_torrent_file(
         &self,
         template: Arc<PathTemplate>,
-        local: LocalPeer,
+        app: Arc<App>,
         shutdown_group: Arc<ShutdownGroup>,
     ) -> Result<(), DownloadInfoError> {
-        let tf = self.get_torrent_file(local, shutdown_group).await?;
+        let tf = self.get_torrent_file(app, shutdown_group).await?;
         tf.save(&template).await?;
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod asyncutil;
+mod config;
 mod consts;
 mod magnet;
 mod peer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,9 +56,13 @@ impl Arguments {
         let cfg = if self.no_config {
             Config::default()
         } else {
-            let (cfgpath, defpath) = match self.config.take() {
-                Some(p) => (p, false),
-                None => (Config::default_path(), true),
+            let (cfgpath, defpath) = if let Some(p) = self.config.take() {
+                (p, false)
+            } else if let Some(p) = Config::default_path() {
+                (p, true)
+            } else {
+                log::error!("Failed to locate configuration file: could not determine user's home directory");
+                return ExitCode::FAILURE;
             };
             log::debug!(
                 "Reading program configuration from {} ...",

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,9 @@ impl Arguments {
                 Err(ConfigError::Read(e))
                     if e.kind() == std::io::ErrorKind::NotFound && defpath =>
                 {
-                    log::debug!("Configuration file is default setting, and file does not exist; using default configuration");
+                    log::debug!(
+                        "Default configuration file does not exist; using default settings"
+                    );
                     Config::default()
                 }
                 Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ mod util;
 use crate::app::App;
 use crate::asyncutil::{BufferedTasks, ShutdownGroup};
 use crate::config::{Config, ConfigError};
-use crate::consts::{MAGNET_LIMIT, TRACKER_STOP_TIMEOUT};
 use crate::magnet::{parse_magnets_file, Magnet};
 use crate::peer::Peer;
 use crate::torrent::{PathTemplate, TorrentFile};
@@ -173,7 +172,7 @@ impl Command {
                 } else {
                     ExitCode::SUCCESS
                 };
-                group.shutdown(TRACKER_STOP_TIMEOUT).await;
+                group.shutdown(app.cfg.trackers.shutdown_timeout).await;
                 r
             }
             Command::Batch { outfile, file } => {
@@ -193,7 +192,7 @@ impl Command {
                 let mut total = 0usize;
                 let outfile = Arc::new(outfile);
                 let mut tasks = BufferedTasks::from_iter(
-                    MAGNET_LIMIT,
+                    app.cfg.general.batch_jobs.get(),
                     magnets.into_iter().map(|magnet| {
                         let gr = Arc::clone(&group);
                         let app = Arc::clone(&app);
@@ -220,7 +219,7 @@ impl Command {
                 log::info!(
                     "{success}/{total} magnet links successfully converted to torrent files"
                 );
-                group.shutdown(TRACKER_STOP_TIMEOUT).await;
+                group.shutdown(app.cfg.trackers.shutdown_timeout).await;
                 if success == total {
                     ExitCode::SUCCESS
                 } else {
@@ -252,7 +251,7 @@ impl Command {
                         ExitCode::FAILURE
                     }
                 };
-                group.shutdown(TRACKER_STOP_TIMEOUT).await;
+                group.shutdown(app.cfg.trackers.shutdown_timeout).await;
                 r
             }
             Command::QueryPeer {

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -3,9 +3,7 @@ mod messages;
 use self::extensions::*;
 use self::messages::*;
 use crate::app::App;
-use crate::consts::{
-    CLIENT, MAX_PEER_MSG_LEN, PEER_HANDSHAKE_TIMEOUT, SUPPORTED_EXTENSIONS, UT_METADATA,
-};
+use crate::consts::{CLIENT, MAX_PEER_MSG_LEN, SUPPORTED_EXTENSIONS, UT_METADATA};
 use crate::torrent::*;
 use crate::types::{InfoHash, PeerId};
 use bendy::decoding::{Error as BendyError, FromBencode, Object, ResultExt};
@@ -142,7 +140,7 @@ pub(crate) struct InfoGetter<'a> {
 impl<'a> InfoGetter<'a> {
     pub(crate) async fn run(self) -> Result<TorrentInfo, PeerError> {
         log::info!("Requesting info for {} from {}", self.info_hash, self.peer);
-        match timeout(PEER_HANDSHAKE_TIMEOUT, self.connect()).await {
+        match timeout(self.app.cfg.peers.handshake_timeout, self.connect()).await {
             Ok(Ok(mut conn)) => conn.get_metadata_info().await,
             Ok(Err(e)) => Err(e),
             Err(_) => Err(PeerError::ConnectTimeout),

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -4,7 +4,7 @@ use self::http::*;
 use self::udp::*;
 use crate::app::App;
 use crate::asyncutil::ShutdownGroup;
-use crate::consts::{LEFT, NUMWANT, TRACKER_TIMEOUT};
+use crate::consts::LEFT;
 use crate::peer::Peer;
 use crate::types::{InfoHash, Key, PeerId};
 use crate::util::{comma_list, ErrorChain};
@@ -38,7 +38,7 @@ impl Tracker {
     ) -> Result<Vec<Peer>, TrackerError> {
         log::info!("Requesting peers for {info_hash} from {self}");
         timeout(
-            TRACKER_TIMEOUT,
+            app.cfg.trackers.announce_timeout,
             self.inner_get_peers(info_hash, app, shutdown_group),
         )
         .await
@@ -147,7 +147,7 @@ impl TrackerSession {
             uploaded: 0,
             event: AnnounceEvent::Started,
             key: self.app.local.key,
-            numwant: NUMWANT,
+            numwant: self.app.cfg.trackers.numwant.get(),
             port: self.app.local.port,
         })
         .await
@@ -167,7 +167,7 @@ impl TrackerSession {
             uploaded: 0,
             event: AnnounceEvent::Stopped,
             key: self.app.local.key,
-            numwant: NUMWANT,
+            numwant: self.app.cfg.trackers.numwant.get(),
             port: self.app.local.port,
         })
         .await

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -2,10 +2,11 @@ pub(crate) mod http;
 pub(crate) mod udp;
 use self::http::*;
 use self::udp::*;
+use crate::app::App;
 use crate::asyncutil::ShutdownGroup;
 use crate::consts::{LEFT, NUMWANT, TRACKER_TIMEOUT};
 use crate::peer::Peer;
-use crate::types::{InfoHash, Key, LocalPeer, PeerId};
+use crate::types::{InfoHash, Key, PeerId};
 use crate::util::{comma_list, ErrorChain};
 use bytes::Bytes;
 use std::fmt;
@@ -32,13 +33,13 @@ impl Tracker {
     pub(crate) async fn get_peers(
         &self,
         info_hash: InfoHash,
-        local: LocalPeer,
+        app: Arc<App>,
         shutdown_group: Arc<ShutdownGroup>,
     ) -> Result<Vec<Peer>, TrackerError> {
         log::info!("Requesting peers for {info_hash} from {self}");
         timeout(
             TRACKER_TIMEOUT,
-            self.inner_get_peers(info_hash, local, shutdown_group),
+            self.inner_get_peers(info_hash, app, shutdown_group),
         )
         .await
         .unwrap_or(Err(TrackerError::Timeout))
@@ -47,10 +48,10 @@ impl Tracker {
     async fn inner_get_peers(
         &self,
         info_hash: InfoHash,
-        local: LocalPeer,
+        app: Arc<App>,
         shutdown_group: Arc<ShutdownGroup>,
     ) -> Result<Vec<Peer>, TrackerError> {
-        let mut s = self.connect(info_hash, local).await?;
+        let mut s = self.connect(info_hash, app).await?;
         let peers = s.start().await?.peers;
         let display = self.to_string();
         log::info!("{display} returned {} peers for {info_hash}", peers.len());
@@ -77,7 +78,7 @@ impl Tracker {
     async fn connect(
         &self,
         info_hash: InfoHash,
-        local: LocalPeer,
+        app: Arc<App>,
     ) -> Result<TrackerSession, TrackerError> {
         let inner = match self {
             Tracker::Http(t) => InnerTrackerSession::Http(t.connect()?),
@@ -86,7 +87,7 @@ impl Tracker {
         Ok(TrackerSession {
             inner,
             info_hash,
-            local,
+            app,
         })
     }
 }
@@ -116,7 +117,7 @@ impl FromStr for Tracker {
 struct TrackerSession {
     inner: InnerTrackerSession,
     info_hash: InfoHash,
-    local: LocalPeer,
+    app: Arc<App>,
 }
 
 enum InnerTrackerSession {
@@ -140,14 +141,14 @@ impl TrackerSession {
         );
         self.announce(Announcement {
             info_hash: self.info_hash,
-            peer_id: self.local.id,
+            peer_id: self.app.local.id,
             downloaded: 0,
             left: LEFT,
             uploaded: 0,
             event: AnnounceEvent::Started,
-            key: self.local.key,
+            key: self.app.local.key,
             numwant: NUMWANT,
-            port: self.local.port,
+            port: self.app.local.port,
         })
         .await
     }
@@ -160,14 +161,14 @@ impl TrackerSession {
         );
         self.announce(Announcement {
             info_hash: self.info_hash,
-            peer_id: self.local.id,
+            peer_id: self.app.local.id,
             downloaded: 0,
             left: LEFT,
             uploaded: 0,
             event: AnnounceEvent::Stopped,
-            key: self.local.key,
+            key: self.app.local.key,
             numwant: NUMWANT,
-            port: self.local.port,
+            port: self.app.local.port,
         })
         .await
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,3 @@
-use crate::consts::PEER_ID_PREFIX;
 use crate::util::{PacketError, TryFromBuf};
 use bytes::{Buf, Bytes};
 use data_encoding::{DecodeError, BASE32, HEXLOWER_PERMISSIVE};
@@ -93,32 +92,6 @@ pub(crate) enum InfoHashError {
     InvalidBase32(#[source] DecodeError),
     #[error("info hash is {0} bytes long, expected 20")]
     InvalidLength(usize),
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(crate) struct LocalPeer {
-    pub(crate) id: PeerId,
-    pub(crate) key: Key,
-    pub(crate) port: u16,
-}
-
-impl LocalPeer {
-    pub(crate) fn generate<R: Rng>(mut rng: R) -> LocalPeer {
-        let id = PeerId::generate(PEER_ID_PREFIX, &mut rng);
-        let key = rng.random::<Key>();
-        let port = rng.random_range::<u16, _>(1025..=65535);
-        LocalPeer { id, key, port }
-    }
-}
-
-impl fmt::Display for LocalPeer {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "id = {}, key = {}, port = {}",
-            self.id, self.key, self.port
-        )
-    }
 }
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -12,6 +12,7 @@ fn test_get(magnet: &str, hash: &str, trackers: &[&str]) {
     Command::cargo_bin("demagnetize")
         .unwrap()
         .arg("--log-level=TRACE")
+        .arg("--no-config")
         .arg("get")
         .arg("-o")
         .arg(tmp_path.path().join("{hash}.torrent"))


### PR DESCRIPTION
Closes #106.

To Do:

- [x] Add a global `-c`/`--config` option
    - When this option is not given and the default config file does not exist, use the default configuration.  When this option is given and the given file does not exist, error.
- [x] Add a `--no-config` global option and use it in the integration tests
- [x] Error if `directories` cannot determine user's home directory
- [x] Use the config settings in place of the respective constants from `consts.rs` and delete the latter
- [x] Update README
- [x] Update CHANGELOG
- [x] Create issues for deferred items from #106